### PR TITLE
Update index.mdx

### DIFF
--- a/src/content/landing/index.mdx
+++ b/src/content/landing/index.mdx
@@ -18,11 +18,12 @@ import BasicFeature from "../../components/sections/basic-feature.astro";
 
         ELIXIR Norway is a national node of [ELIXIR](https://elixir-europe.org/), the pan-European
         infrastructure for _biological information_, supporting life science research
-        and its translation to medicine, environment, the bioindustries and society.
+        and its translation to medicine, the environment, the bioindustries and society.
 
-        ELIXIR Norway is funded by the [Research Council of Norway](https://www.forskningsradet.no/en/)
-        and its partners, and builds upon the Norwegian Bioinformatics Platform, which has
-        provided support and tools for Norwegian life science research for nearly two decades.
+        ELIXIR Norway is funded by the [Research Council of Norway](https://www.forskningsradet.no/en/),
+        its partner institutions, and the [ELIXIR Hub](https://elixir-europe.org/about-us/who-we-are/hub).
+        ELIXIR Norway builds upon the Norwegian Bioinformatics Platform, which has
+        provided support and tools for Norwegian life science research for over two decades.
     </div>
     <Carousel client:visible images={[
         {


### PR DESCRIPTION
Minor updates and clarification on funding in the general description.

Closes https://github.com/ELIXIR-NO/website/issues/38. 

Note that I changed "nearly two decades" to "over two decades", as FUGE is dated 2021 (see e.g. [here](https://www.forskningsradet.no/siteassets/publikasjoner/1108644085526.pdf).) But please let me know if this is not correct. 