### PR TITLE
refining keywords

### DIFF
--- a/src/content/projects/b1mg.mdx
+++ b/src/content/projects/b1mg.mdx
@@ -11,7 +11,7 @@ project_number:
   link: https://doi.org/10.3030/951724
 period: 2020-06 2023-10
 external_link: https://b1mg-project.eu/
-keywords: ["human", "genome", "infrastructure"]
+keywords: ["human data", "genome", "infrastructure"]
 draft: false
 ---
 

--- a/src/content/projects/b1mg.mdx
+++ b/src/content/projects/b1mg.mdx
@@ -11,7 +11,7 @@ project_number:
   link: https://doi.org/10.3030/951724
 period: 2020-06 2023-10
 external_link: https://b1mg-project.eu/
-keywords: ["human", "genome", "reference", "infrastructure"]
+keywords: ["human", "genome", "infrastructure"]
 draft: false
 ---
 

--- a/src/content/projects/by-covid.mdx
+++ b/src/content/projects/by-covid.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://doi.org/10.3030/101046203
 period: 2021-10 2024-09
 external_link: https://by-covid.org/
-keywords: ["pathogen", "covid", "brokering"]
+keywords: ["pathogen", "data management"]
 draft: false
 ---
 

--- a/src/content/projects/data-management-research-elixir-datarex.mdx
+++ b/src/content/projects/data-management-research-elixir-datarex.mdx
@@ -11,7 +11,7 @@ project_number:
     link: 
 period: 2024-01 2025-12
 external_link: https://elixir-europe.org/internal-projects/commissioned-services/datarex
-keywords: ["FAIR", "RDM", "training", "brokering"]
+keywords: ["FAIR", "data management", "training"]
 draft: false
 ---
 

--- a/src/content/projects/elixir-converge.mdx
+++ b/src/content/projects/elixir-converge.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://doi.org/10.3030/871075
 period: 2020-02 2023-07
 external_link: https://elixir-europe.org/about-us/how-funded/eu-projects/converge
-keywords: ["FAIR", "training", "human"]
+keywords: ["FAIR", "training", "human data"]
 draft: false
 ---
 

--- a/src/content/projects/elixir-interoperability-platform-knowledgehub.mdx
+++ b/src/content/projects/elixir-interoperability-platform-knowledgehub.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://elixir-europe.org/internal-projects/commissioned-services/2022-eip2
 period: 2022-01 2023-12
 external_link:
-keywords: ["FAIR", "RDM"]
+keywords: ["FAIR", "data management"]
 draft: false
 ---
 

--- a/src/content/projects/elixir-node-support.mdx
+++ b/src/content/projects/elixir-node-support.mdx
@@ -11,7 +11,7 @@ project_number:
     link: 
 period: 2024-01 2026-12
 external_link: https://elixir-europe.org/internal-projects/nodes
-keywords: ["Sustainability", "diversity", "management"]
+keywords: ["diversity", "management"]
 draft: false
 ---
 

--- a/src/content/projects/elixir-people-support.mdx
+++ b/src/content/projects/elixir-people-support.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://elixir-europe.org/internal-projects/people
 period: 2024-01 2026-12
 external_link: https://elixir-europe.org/internal-projects/people
-keywords: ["diversity", "management", "training", "impact"]
+keywords: ["diversity", "management", "training"]
 draft: false
 ---
 

--- a/src/content/projects/elixir-people-support.mdx
+++ b/src/content/projects/elixir-people-support.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://elixir-europe.org/internal-projects/people
 period: 2024-01 2026-12
 external_link: https://elixir-europe.org/internal-projects/people
-keywords: ["diversity", "management", "training"]
+keywords: ["diversity", "management", "training", "impact"]
 draft: false
 ---
 

--- a/src/content/projects/elixir-tools-platform-strategic-programme-2024-2028.mdx
+++ b/src/content/projects/elixir-tools-platform-strategic-programme-2024-2028.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://elixir-europe.org/internal-projects/technology
 period: 2024-01 2026-12
 external_link: https://elixir-europe.org/platforms/tools
-keywords: ["tools", "FAIR", "software", "workflow", "machine-learning"]
+keywords: ["tools", "FAIR", "workflow"]
 draft: false
 ---
 

--- a/src/content/projects/eosc-entrust.mdx
+++ b/src/content/projects/eosc-entrust.mdx
@@ -11,7 +11,7 @@ project_number:
   link: https://doi.org/10.3030/101131056
 period: 2024-03 2027-02
 external_link:  https://eosc-entrust.eu/
-keywords: ["FAIR", "interoperability", "human", "compute"]
+keywords: ["FAIR", "interoperability", "human data", "compute"]
 draft: false
 ---
 

--- a/src/content/projects/eosc-life.mdx
+++ b/src/content/projects/eosc-life.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://doi.org/10.3030/824087
 period: 2019-03 2023-08
 external_link: https://www.eosc-life.eu/
-keywords: ["EOSC", "ESFRI", "Cloud"]
+keywords: ["infrastructure", "cloud"]
 draft: false
 ---
 

--- a/src/content/projects/euro-science-gateway.mdx
+++ b/src/content/projects/euro-science-gateway.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://doi.org/10.3030/101057388
 period: 2022-09 2025-08
 external_link: https://eosc.eu/eu-project/eurosciencegateway/
-keywords: ["FAIR", "HPC", "workflow", "provenance", "cloud"]
+keywords: ["FAIR", "workflow", "cloud"]
 draft: false
 ---
 

--- a/src/content/projects/excelerate.mdx
+++ b/src/content/projects/excelerate.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://doi.org/10.3030/676559
 period: 2015-09 2019-08
 external_link: https://elixir-europe.org/about-us/how-funded/eu-projects/excelerate
-keywords: ["infrastructure", "data management", "human"]
+keywords: ["infrastructure", "data management", "human data"]
 draft: false
 ---
 

--- a/src/content/projects/excelerate.mdx
+++ b/src/content/projects/excelerate.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://doi.org/10.3030/676559
 period: 2015-09 2019-08
 external_link: https://elixir-europe.org/about-us/how-funded/eu-projects/excelerate
-keywords: ["life science data", "health", "agriculture", "data management", "biotechnology"]
+keywords: ["infrastructure", "data management", "human"]
 draft: false
 ---
 

--- a/src/content/projects/federated-ega-sensitive-data-management.mdx
+++ b/src/content/projects/federated-ega-sensitive-data-management.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://elixir-europe.org/internal-projects/commissioned-services/2022-fhd
 period: 2022-01 2023-12
 external_link: https://elixir-europe.org/internal-projects/commissioned-services/2022-fhd
-keywords: ["FAIR", "training", "human", "compute", "tools"]
+keywords: ["FAIR", "training", "human data", "compute", "tools"]
 draft: false
 ---
 

--- a/src/content/projects/federated-ega-sensitive-data-management.mdx
+++ b/src/content/projects/federated-ega-sensitive-data-management.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://elixir-europe.org/internal-projects/commissioned-services/2022-fhd
 period: 2022-01 2023-12
 external_link: https://elixir-europe.org/internal-projects/commissioned-services/2022-fhd
-keywords: ["FAIR", "training", "human", "compute", "tool"]
+keywords: ["FAIR", "training", "human", "compute", "tools"]
 draft: false
 ---
 

--- a/src/content/projects/federated-human-data.mdx
+++ b/src/content/projects/federated-human-data.mdx
@@ -11,7 +11,7 @@ project_number:
     link:
 period: 2019-05 2021-12
 external_link:
-keywords: []
+keywords: ["human data"]
 draft: true
 ---
 

--- a/src/content/projects/genome-of-europe.mdx
+++ b/src/content/projects/genome-of-europe.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://ec.europa.eu/info/funding-tenders/opportunities/portal/screen/opportunities/projects-details/43152860/101168231
 period: 2024-10 2028-03
 external_link: https://b1mg-project.eu/1mg/genome-europe
-keywords: ["genome", "infrastructure", "human"]
+keywords: ["genome", "infrastructure", "human data"]
 draft: false
 ---
 

--- a/src/content/projects/genomic-data-infrastructure.mdx
+++ b/src/content/projects/genomic-data-infrastructure.mdx
@@ -11,7 +11,7 @@ project_number:
     link: https://ec.europa.eu/info/funding-tenders/opportunities/portal/screen/opportunities/projects-details/43152860/101081813
 period: 2022-11 2026-10
 external_link: https://gdi.onemilliongenomes.eu/
-keywords: ["genome", "infrastructure", "human"]
+keywords: ["genome", "infrastructure", "human data"]
 draft: false
 ---
 

--- a/src/content/projects/infrastructure-service-roadmap-tools-ecosystem.mdx
+++ b/src/content/projects/infrastructure-service-roadmap-tools-ecosystem.mdx
@@ -12,7 +12,7 @@ project_number:
     link: https://elixir-europe.org/internal-projects/commissioned-services/tools-platform-ecosystem
 period: 2021-06 2023-12
 external_link: https://elixir-europe.org/internal-projects/commissioned-services/tools-platform-ecosystem
-keywords: ["tools", "interoperability", "metadata"]
+keywords: ["tools", "interoperability"]
 draft: false
 ---
 

--- a/src/content/projects/pdn.mdx
+++ b/src/content/projects/pdn.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Pathogen Data Network - PDN"
+title: "Pathogen Data Network (PDN)"
 summary: "The mission of the Pathogen Data Network is to enable a world-wide ecosystem of linked data and tools to support research and public health response to infectious diseases and epidemics."
 status: "ongoing"
 category: "global"
@@ -11,7 +11,7 @@ project_number:
     link: https://reporter.nih.gov/search/4mSZqMOZwkutmDnsvJqj6Q/project-details/10913643
 period: 2024-09 2028-06
 external_link: https://pathogendatanetwork.org/
-keywords: ["pathogen", "infectious diseases", "surveillance"]
+keywords: ["pathogen", "infrastructure"]
 draft: false
 ---
 

--- a/src/content/projects/strengthen-galaxy-data-management.mdx
+++ b/src/content/projects/strengthen-galaxy-data-management.mdx
@@ -11,7 +11,7 @@ project_number:
     link:
 period: 2021-05 - 2023-05
 external_link: https://elixir-europe.org/internal-projects/commissioned-services/strengthen-data-management-galaxy
-keywords: ["RDM", "Galaxy", "sensitive data"]
+keywords: ["data management", "human"]
 draft: false
 ---
 

--- a/src/content/projects/strengthen-galaxy-data-management.mdx
+++ b/src/content/projects/strengthen-galaxy-data-management.mdx
@@ -11,7 +11,7 @@ project_number:
     link:
 period: 2021-05 - 2023-05
 external_link: https://elixir-europe.org/internal-projects/commissioned-services/strengthen-data-management-galaxy
-keywords: ["data management", "human"]
+keywords: ["data management", "human data"]
 draft: false
 ---
 


### PR DESCRIPTION
I have tried to reduce the number of keywords to make the sidebar look more sensible: 

* I have removed obvious synonyms (e.g. RDM and data management)
* I have removed keywords that were used only in one project

Obviously, one can always do better with these annotations, but this should at least tame a bit the "keyword chaos". 