### PR TITLE
feat(cms): PR dashboard, lazy loading, branch indicator, rich markdown editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gray-matter": "^4.0.3",
     "leaflet": "^1.9.4",
     "lodash": "^4.17.23",
+    "marked": "^17.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       lodash:
         specifier: ^4.17.23
         version: 4.17.23
+      marked:
+        specifier: ^17.0.5
+        version: 17.0.5
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -2494,6 +2497,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@17.0.5:
+    resolution: {integrity: sha512-6hLvc0/JEbRjRgzI6wnT2P1XuM1/RrrDEX0kPt0N7jGm1133g6X7DlxFasUIx+72aKAr904GTxhSLDrd5DIlZg==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -6621,6 +6629,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  marked@17.0.5: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:

--- a/src/components/admin/AdminApp.tsx
+++ b/src/components/admin/AdminApp.tsx
@@ -238,6 +238,40 @@ interface Entry {
 
 const BASE = import.meta.env.BASE_URL?.replace(/\/$/, '') || '';
 
+function BranchPill({ branch }: { branch: string }) {
+    return (
+        <span className="inline-flex items-center gap-1 text-xs text-gray-500 font-mono bg-white/[0.05] px-2 py-0.5 rounded-full">
+            <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
+            </svg>
+            {branch}
+        </span>
+    );
+}
+
+const PAGE_SIZE = 5;
+
+async function loadBatch(
+    token: string,
+    collection: ContentCollection,
+    files: GitHubFile[],
+    offset: number,
+): Promise<Entry[]> {
+    const batch = files.slice(offset, offset + PAGE_SIZE);
+    const entries: Entry[] = [];
+    for (const f of batch) {
+        try {
+            const content = await readFile(token, f.path);
+            const { data, body } = parseFrontmatter(content);
+            const slug = f.path
+                .replace(collection.folder + '/', '')
+                .replace('/index.mdx', '');
+            entries.push({ path: f.path, slug, data, body });
+        } catch { /* skip unreadable files */ }
+    }
+    return entries;
+}
+
 function LoginScreen({ onLogin }: { onLogin: () => void }) {
     return (
         <div className="min-h-screen flex items-center justify-center bg-dark-background">
@@ -356,45 +390,41 @@ function CollectionView({
     onEntriesLoaded: (entries: Entry[]) => void;
 }) {
     const [entries, setEntries] = useState<Entry[]>([]);
+    const [allFiles, setAllFiles] = useState<GitHubFile[]>([]);
     const [loading, setLoading] = useState(true);
-    const [progress, setProgress] = useState({ loaded: 0, total: 0 });
+    const [loadingMore, setLoadingMore] = useState(false);
 
     useEffect(() => {
         setLoading(true);
-        setProgress({ loaded: 0, total: 0 });
+        setEntries([]);
+        setAllFiles([]);
         (async () => {
             const files = await listFiles(token, collection.folder + '/');
             const indexFiles = files.filter((f) => f.path.endsWith('/index.mdx'));
-            setProgress({ loaded: 0, total: indexFiles.length });
+            indexFiles.sort((a, b) => b.path.localeCompare(a.path));
+            setAllFiles(indexFiles);
 
-            const loaded: Entry[] = [];
-            for (const f of indexFiles) {
-                try {
-                    const content = await readFile(token, f.path);
-                    const { data, body } = parseFrontmatter(content);
-                    const slug = f.path
-                        .replace(collection.folder + '/', '')
-                        .replace('/index.mdx', '');
-                    loaded.push({ path: f.path, slug, data, body });
-                } catch { /* skip unreadable files */ }
-                setProgress(p => ({ ...p, loaded: loaded.length }));
-            }
-
-            loaded.sort((a, b) => {
-                const da = String(a.data.date || a.data.title || '');
-                const db = String(b.data.date || b.data.title || '');
-                return db.localeCompare(da);
-            });
-
-            setEntries(loaded);
-            onEntriesLoaded(loaded);
+            const firstBatch = await loadBatch(token, collection, indexFiles, 0);
+            setEntries(firstBatch);
+            onEntriesLoaded(firstBatch);
             setLoading(false);
         })();
     }, [collection.name, token]);
 
+    const handleLoadMore = async () => {
+        setLoadingMore(true);
+        const next = await loadBatch(token, collection, allFiles, entries.length);
+        const updated = [...entries, ...next];
+        setEntries(updated);
+        onEntriesLoaded(updated);
+        setLoadingMore(false);
+    };
+
+    const remaining = allFiles.length - entries.length;
+
     return (
         <div className="flex-1 p-6 sm:p-8 overflow-y-auto">
-            <div className="flex items-center justify-between mb-6">
+            <div className="flex items-center justify-between mb-2">
                 <h2 className="text-xl font-bold text-white">{collection.label}</h2>
                 {collection.canCreate && (
                     <button
@@ -408,6 +438,12 @@ function CollectionView({
                     </button>
                 )}
             </div>
+            <div className="flex items-center gap-2 mb-6">
+                <BranchPill branch="main" />
+                {!loading && (
+                    <span className="text-xs text-gray-500">{allFiles.length} {allFiles.length === 1 ? 'entry' : 'entries'}</span>
+                )}
+            </div>
 
             <div className="grid grid-cols-1 xl:grid-cols-[1fr_280px] gap-8">
                 <div>
@@ -417,19 +453,7 @@ function CollectionView({
                                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                             </svg>
-                            <span className="text-xs text-gray-500 mt-3">
-                                {progress.total > 0
-                                    ? `Loading ${progress.loaded} of ${progress.total} entries...`
-                                    : 'Fetching file list...'}
-                            </span>
-                            {progress.total > 0 && (
-                                <div className="w-48 h-1 rounded-full bg-gray-700 mt-2 overflow-hidden">
-                                    <div
-                                        className="h-full bg-accent rounded-full transition-all duration-200"
-                                        style={{ width: `${(progress.loaded / progress.total) * 100}%` }}
-                                    />
-                                </div>
-                            )}
+                            <span className="text-xs text-gray-500 mt-3">Fetching entries...</span>
                         </div>
                     ) : entries.length === 0 ? (
                         <p className="text-sm text-gray-400">No entries found.</p>
@@ -450,6 +474,25 @@ function CollectionView({
                                     </div>
                                 </button>
                             ))}
+                            {remaining > 0 && (
+                                <button
+                                    onClick={handleLoadMore}
+                                    disabled={loadingMore}
+                                    className="w-full mt-3 px-4 py-3 rounded-lg border border-dashed border-gray-700/40 text-sm text-gray-400 hover:text-accent hover:border-accent/30 transition-colors disabled:opacity-50"
+                                >
+                                    {loadingMore ? (
+                                        <span className="inline-flex items-center gap-2">
+                                            <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                                                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                                            </svg>
+                                            Loading...
+                                        </span>
+                                    ) : (
+                                        `Show more (${remaining} remaining)`
+                                    )}
+                                </button>
+                            )}
                         </div>
                     )}
                 </div>
@@ -459,11 +502,6 @@ function CollectionView({
                     <div className="sticky top-8 rounded-xl border border-gray-700/30 bg-white/[0.02] p-5">
                         <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">About this collection</h3>
                         <p className="text-sm text-gray-400 leading-relaxed">{collection.description}</p>
-                        {!loading && (
-                            <p className="text-xs text-gray-500 mt-4">
-                                {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
-                            </p>
-                        )}
                     </div>
                 </div>
             </div>

--- a/src/components/admin/AdminApp.tsx
+++ b/src/components/admin/AdminApp.tsx
@@ -5,6 +5,7 @@ import SlidesEditor from './SlidesEditor';
 import BannerEditor from './BannerEditor';
 import MarkdownEditor from './MarkdownEditor';
 import PRConfirmDialog from './PRConfirmDialog';
+import BranchPill from './BranchPill';
 
 /** Sanitize a string to kebab-case for slugs and filenames */
 function toKebab(str: string): string {
@@ -237,17 +238,6 @@ interface Entry {
 // ─── Components ──────────────────────────────────────────
 
 const BASE = import.meta.env.BASE_URL?.replace(/\/$/, '') || '';
-
-function BranchPill({ branch }: { branch: string }) {
-    return (
-        <span className="inline-flex items-center gap-1 text-xs text-gray-500 font-mono bg-white/[0.05] px-2 py-0.5 rounded-full">
-            <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
-            </svg>
-            {branch}
-        </span>
-    );
-}
 
 const PAGE_SIZE = 5;
 
@@ -927,9 +917,12 @@ function EntryEditor({
                     Back to {collection.label}
                 </button>
 
-                <h2 className="text-xl font-bold text-white mb-6">
+                <h2 className="text-xl font-bold text-white mb-1">
                     {isNew ? `New ${collection.label}` : String(data.title || entry.slug)}
                 </h2>
+                <div className="mb-6">
+                    <BranchPill branch={branchOverride || 'main'} />
+                </div>
 
                 {isNew && (
                     <div className="mb-5">

--- a/src/components/admin/AdminApp.tsx
+++ b/src/components/admin/AdminApp.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
-import { collections, getCollection, detectCollection, type Collection, type Field, type ContentCollection, type JsonCollection } from './schema';
+import { collections, getCollection, type Collection, type Field, type ContentCollection } from './schema';
 import PeopleEditor from './PeopleEditor';
 import SlidesEditor from './SlidesEditor';
 import BannerEditor from './BannerEditor';

--- a/src/components/admin/AdminApp.tsx
+++ b/src/components/admin/AdminApp.tsx
@@ -664,6 +664,7 @@ function EntryEditor({
     isNew,
     allEntries,
     user,
+    branchOverride,
 }: {
     collection: ContentCollection;
     entry: Entry;
@@ -672,6 +673,7 @@ function EntryEditor({
     isNew: boolean;
     allEntries: Entry[];
     user: { login: string } | null;
+    branchOverride?: string;
 }) {
     // Auto-save draft key
     const draftKey = `cms-draft:${collection.name}:${isNew ? '__new__' : entry.path}`;
@@ -807,6 +809,19 @@ function EntryEditor({
 
         files.push({ path: filePath, content: mdxContent });
 
+        if (branchOverride) {
+            setSaving(true);
+            try {
+                await commitToBranch(token, branchOverride, files);
+                clearDraft();
+                setResult({ prUrl: '', branch: branchOverride });
+            } catch (err) {
+                alert(`Save failed: ${err}`);
+            }
+            setSaving(false);
+            return;
+        }
+
         const title = String(cleanData.title || finalSlug);
         const defaultTitle = `[CMS] ${isNew ? 'Add' : 'Update'} ${collection.label}: ${title}`;
         setConfirmDialog({ files, defaultTitle });
@@ -839,21 +854,26 @@ function EntryEditor({
                             <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
                         </svg>
                     </div>
-                    <h3 className="text-lg font-bold text-white mb-2">Pull request created</h3>
+                    <h3 className="text-lg font-bold text-white mb-2">{branchOverride ? 'Changes pushed' : 'Pull request created'}</h3>
                     <p className="text-sm text-gray-400 mb-6">
-                        Your changes have been saved to branch <code className="text-xs bg-gray-800 px-1.5 py-0.5 rounded">{result.branch}</code> and a PR has been opened for review.
+                        {branchOverride
+                            ? <>Your changes have been pushed to branch <code className="text-xs bg-gray-800 px-1.5 py-0.5 rounded">{result.branch}</code>.</>
+                            : <>Your changes have been saved to branch <code className="text-xs bg-gray-800 px-1.5 py-0.5 rounded">{result.branch}</code> and a PR has been opened for review.</>
+                        }
                     </p>
                     <div className="flex gap-3 justify-center">
-                        <a
-                            href={result.prUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="px-4 py-2 text-sm font-semibold rounded-lg bg-accent text-white hover:opacity-90 transition-opacity"
-                        >
-                            View PR on GitHub
-                        </a>
+                        {result.prUrl && (
+                            <a
+                                href={result.prUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="px-4 py-2 text-sm font-semibold rounded-lg bg-accent text-white hover:opacity-90 transition-opacity"
+                            >
+                                View PR on GitHub
+                            </a>
+                        )}
                         <button onClick={onBack} className="px-4 py-2 text-sm font-semibold rounded-lg border border-gray-600 text-gray-300 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors">
-                            Back to list
+                            {branchOverride ? 'Back to Pull Requests' : 'Back to list'}
                         </button>
                     </div>
                 </div>
@@ -921,7 +941,7 @@ function EntryEditor({
                         disabled={saving}
                         className="px-6 py-2.5 text-sm font-semibold rounded-lg bg-accent text-white hover:opacity-90 transition-opacity disabled:opacity-50"
                     >
-                        {saving ? 'Saving...' : 'Save as Pull Request'}
+                        {saving ? 'Saving...' : branchOverride ? 'Push to PR' : 'Save as Pull Request'}
                     </button>
                     <button
                         onClick={() => { clearDraft(); onBack(); }}

--- a/src/components/admin/AdminApp.tsx
+++ b/src/components/admin/AdminApp.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
-import { collections, getCollection, type Collection, type Field, type ContentCollection } from './schema';
+import { collections, getCollection, detectCollection, type Collection, type Field, type ContentCollection, type JsonCollection } from './schema';
 import PeopleEditor from './PeopleEditor';
 import SlidesEditor from './SlidesEditor';
 import BannerEditor from './BannerEditor';
@@ -15,9 +15,11 @@ function toKebab(str: string): string {
         .replace(/(^-|-$)/g, '');
 }
 import {
-    listFiles, readFile, readJsonFile, saveAsPR, getUser, hasWriteAccess, cacheClear,
-    type GitHubFile, type SaveResult,
+    listFiles, readFile, readJsonFile, saveAsPR, commitToBranch, readFileFromRef,
+    getUser, hasWriteAccess, cacheClear,
+    type GitHubFile, type SaveResult, type PullRequest, type PRFile,
 } from './github';
+import OpenPRsView from './OpenPRsView';
 
 // ─── Auth ────────────────────────────────────────────────
 
@@ -267,6 +269,7 @@ function Sidebar({
     onLogout,
     mobileOpen,
     onMobileClose,
+    prCount,
 }: {
     activeCollection: string;
     onSelect: (name: string) => void;
@@ -274,6 +277,7 @@ function Sidebar({
     onLogout: () => void;
     mobileOpen: boolean;
     onMobileClose: () => void;
+    prCount: number | null;
 }) {
     return (
         <>
@@ -289,6 +293,27 @@ function Sidebar({
                 </button>
             </div>
             <nav className="flex-1 py-3 px-2 space-y-0.5 overflow-y-auto">
+                <button
+                    onClick={() => { onSelect('pull-requests'); onMobileClose(); }}
+                    className={`w-full text-left px-3 py-2 text-sm rounded-lg transition-colors flex items-center justify-between ${
+                        activeCollection === 'pull-requests'
+                            ? 'bg-accent/10 text-accent font-semibold'
+                            : 'text-gray-400 hover:bg-white/5 hover:text-gray-200'
+                    }`}
+                >
+                    <span className="flex items-center gap-2">
+                        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden="true">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
+                        </svg>
+                        Pull Requests
+                    </span>
+                    {prCount !== null && prCount > 0 && (
+                        <span className="rounded-full bg-accent/20 text-accent px-1.5 py-0.5 text-xs font-semibold min-w-[1.25rem] text-center">
+                            {prCount}
+                        </span>
+                    )}
+                </button>
+                <div className="my-1 border-t border-gray-700/20" />
                 {collections.map((c) => (
                     <button
                         key={c.name}
@@ -953,11 +978,13 @@ function GlobalLoader() {
 
 export default function AdminApp() {
     const { token, user, authorized, login, logout } = useAuth();
-    const [activeCollection, setActiveCollection] = useState(collections[0].name);
+    const [activeCollection, setActiveCollection] = useState('pull-requests');
     const [editingEntry, setEditingEntry] = useState<Entry | null>(null);
     const [isNew, setIsNew] = useState(false);
     const [loadedEntries, setLoadedEntries] = useState<Entry[]>([]);
     const [mobileNav, setMobileNav] = useState(false);
+    const [prCount, setPrCount] = useState<number | null>(null);
+    const [editingPR, setEditingPR] = useState<{ branch: string; prNumber: number } | null>(null);
 
     if (!token) {
         return <LoginScreen onLogin={login} />;
@@ -980,8 +1007,6 @@ export default function AdminApp() {
         );
     }
 
-    const collection = getCollection(activeCollection)!;
-
     const handleCreate = () => {
         setIsNew(true);
         setEditingEntry({ path: '', slug: '', data: {}, body: '' });
@@ -992,26 +1017,77 @@ export default function AdminApp() {
         setIsNew(false);
     };
 
-    function renderContent() {
-        // JSON data editors
+    const handleEditPR = async (pr: PullRequest, collection: Collection, files: PRFile[]) => {
+        setEditingPR({ branch: pr.head.ref, prNumber: pr.number });
+
         if (collection.kind === 'json') {
-            if (collection.name === 'people') return <PeopleEditor token={token} username={user?.login || 'cms'} />;
-            if (collection.name === 'slides') return <SlidesEditor token={token} username={user?.login || 'cms'} />;
-            if (collection.name === 'banner') return <BannerEditor token={token} username={user?.login || 'cms'} />;
+            setActiveCollection(collection.name);
+            return;
+        }
+
+        const contentCollection = collection as ContentCollection;
+        const mdxFile = files.find(f => f.filename.endsWith('/index.mdx'));
+        if (!mdxFile) {
+            alert('Could not find content file in this PR.');
+            setEditingPR(null);
+            return;
+        }
+
+        try {
+            const content = await readFileFromRef(token!, mdxFile.filename, pr.head.ref);
+            const { data, body } = parseFrontmatter(content);
+            const slug = mdxFile.filename
+                .replace(contentCollection.folder + '/', '')
+                .replace('/index.mdx', '');
+            setActiveCollection(collection.name);
+            setEditingEntry({ path: mdxFile.filename, slug, data, body });
+            setIsNew(false);
+        } catch (err) {
+            alert(`Failed to load PR content: ${err}`);
+            setEditingPR(null);
+        }
+    };
+
+    const handleBackFromPR = () => {
+        setEditingEntry(null);
+        setIsNew(false);
+        setEditingPR(null);
+        setActiveCollection('pull-requests');
+    };
+
+    function renderContent() {
+        if (activeCollection === 'pull-requests' && !editingEntry) {
+            return (
+                <OpenPRsView
+                    token={token!}
+                    username={user?.login || ''}
+                    onEditPR={handleEditPR}
+                    onCountLoaded={setPrCount}
+                />
+            );
+        }
+
+        const collection = getCollection(activeCollection);
+        if (!collection) return null;
+
+        if (collection.kind === 'json') {
+            if (collection.name === 'people') return <PeopleEditor token={token} username={user?.login || 'cms'} branchOverride={editingPR?.branch} onBack={editingPR ? handleBackFromPR : undefined} />;
+            if (collection.name === 'slides') return <SlidesEditor token={token} username={user?.login || 'cms'} branchOverride={editingPR?.branch} onBack={editingPR ? handleBackFromPR : undefined} />;
+            if (collection.name === 'banner') return <BannerEditor token={token} username={user?.login || 'cms'} branchOverride={editingPR?.branch} onBack={editingPR ? handleBackFromPR : undefined} />;
             return null;
         }
 
-        // MDX content editors
         if (editingEntry) {
             return (
                 <EntryEditor
                     collection={collection}
                     entry={editingEntry}
                     token={token}
-                    onBack={handleBack}
+                    onBack={editingPR ? handleBackFromPR : handleBack}
                     isNew={isNew}
                     allEntries={loadedEntries}
                     user={user}
+                    branchOverride={editingPR?.branch}
                 />
             );
         }
@@ -1031,11 +1107,12 @@ export default function AdminApp() {
         <div className="flex h-screen bg-dark-background">
             <Sidebar
                 activeCollection={activeCollection}
-                onSelect={(name) => { setActiveCollection(name); setEditingEntry(null); setIsNew(false); }}
+                onSelect={(name) => { setActiveCollection(name); setEditingEntry(null); setIsNew(false); setEditingPR(null); }}
                 user={user}
                 onLogout={logout}
                 mobileOpen={mobileNav}
                 onMobileClose={() => setMobileNav(false)}
+                prCount={prCount}
             />
             <div className="flex-1 flex flex-col min-w-0">
                 {/* Mobile header */}
@@ -1043,7 +1120,9 @@ export default function AdminApp() {
                     <button onClick={() => setMobileNav(true)} className="p-1.5 text-gray-400 hover:text-white">
                         <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" /></svg>
                     </button>
-                    <span className="text-sm font-semibold text-white">{getCollection(activeCollection)?.label}</span>
+                    <span className="text-sm font-semibold text-white">
+                        {activeCollection === 'pull-requests' ? 'Pull Requests' : getCollection(activeCollection)?.label}
+                    </span>
                 </div>
                 {renderContent()}
             </div>

--- a/src/components/admin/BannerEditor.tsx
+++ b/src/components/admin/BannerEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { readJsonFile, saveAsPR, type SaveResult } from './github';
+import { readJsonFile, readFileFromRef, saveAsPR, commitToBranch, type SaveResult } from './github';
 import PRConfirmDialog from './PRConfirmDialog';
 
 interface BannerData {
@@ -33,7 +33,7 @@ function renderPreview(md: string): React.ReactNode {
     return parts;
 }
 
-export default function BannerEditor({ token, username }: { token: string; username: string }) {
+export default function BannerEditor({ token, username, branchOverride, onBack }: { token: string; username: string; branchOverride?: string; onBack?: () => void }) {
     const [data, setData] = useState<BannerData | null>(null);
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
@@ -43,20 +43,37 @@ export default function BannerEditor({ token, username }: { token: string; usern
 
     useEffect(() => {
         (async () => {
-            const d = await readJsonFile<BannerData>(token, 'src/data/banner.json');
+            let d: BannerData;
+            if (branchOverride) {
+                const raw = await readFileFromRef(token, 'src/data/banner.json', branchOverride);
+                d = JSON.parse(raw);
+            } else {
+                d = await readJsonFile<BannerData>(token, 'src/data/banner.json');
+            }
             setData(d);
             setLoading(false);
         })();
-    }, [token]);
+    }, [token, branchOverride]);
 
     const update = (patch: Partial<BannerData>) => {
         setData(prev => prev ? { ...prev, ...patch } : prev);
         setDirty(true);
     };
 
-    const preparePublish = () => {
+    const preparePublish = async () => {
         if (!data) return;
         const files = [{ path: 'src/data/banner.json', content: JSON.stringify(data, null, 4) + '\n' }];
+        if (branchOverride) {
+            setSaving(true);
+            try {
+                await commitToBranch(token, branchOverride, files);
+                setResult({ prUrl: '', branch: branchOverride });
+            } catch (err) {
+                alert(`Save failed: ${err}`);
+            }
+            setSaving(false);
+            return;
+        }
         setConfirmDialog({ files });
     };
 
@@ -80,12 +97,21 @@ export default function BannerEditor({ token, username }: { token: string; usern
                     <div className="h-12 w-12 mx-auto mb-4 rounded-full bg-green-900/20 flex items-center justify-center">
                         <svg className="h-6 w-6 text-green-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
                     </div>
-                    <h3 className="text-lg font-bold text-white mb-2">Pull request created</h3>
+                    <h3 className="text-lg font-bold text-white mb-2">{branchOverride ? 'Changes pushed' : 'Pull request created'}</h3>
                     <p className="text-sm text-gray-400 mb-6">Banner updated.</p>
-                    <a href={result.prUrl} target="_blank" rel="noopener noreferrer"
-                        className="px-4 py-2 text-sm font-semibold rounded-lg bg-accent text-white hover:opacity-90 transition-opacity">
-                        View PR on GitHub
-                    </a>
+                    <div className="flex items-center justify-center gap-3">
+                        {result.prUrl && (
+                            <a href={result.prUrl} target="_blank" rel="noopener noreferrer"
+                                className="px-4 py-2 text-sm font-semibold rounded-lg bg-accent text-white hover:opacity-90 transition-opacity">
+                                View PR on GitHub
+                            </a>
+                        )}
+                        {onBack && (
+                            <button onClick={onBack} className="px-4 py-2 text-sm font-semibold rounded-lg border border-gray-600 text-gray-300 hover:bg-white/5 transition-colors">
+                                Back to Pull Requests
+                            </button>
+                        )}
+                    </div>
                 </div>
             </div>
         );
@@ -106,6 +132,12 @@ export default function BannerEditor({ token, username }: { token: string; usern
     return (
         <div className="flex-1 p-6 sm:p-8 overflow-y-auto">
             <div className="max-w-2xl">
+                {onBack && (
+                    <button onClick={onBack} className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-white mb-6 transition-colors">
+                        <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" /></svg>
+                        Back to Pull Requests
+                    </button>
+                )}
                 <div className="flex items-center justify-between mb-8">
                     <div>
                         <h2 className="text-xl font-bold text-white">Site Banner</h2>
@@ -114,7 +146,7 @@ export default function BannerEditor({ token, username }: { token: string; usern
                     {dirty && (
                         <button onClick={preparePublish} disabled={saving}
                             className="px-4 py-2 text-sm font-semibold rounded-lg bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 transition-colors">
-                            {saving ? 'Saving...' : 'Publish Changes'}
+                            {saving ? 'Saving...' : branchOverride ? 'Push to PR' : 'Publish Changes'}
                         </button>
                     )}
                 </div>

--- a/src/components/admin/BannerEditor.tsx
+++ b/src/components/admin/BannerEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { readJsonFile, readFileFromRef, saveAsPR, commitToBranch, type SaveResult } from './github';
 import PRConfirmDialog from './PRConfirmDialog';
+import BranchPill from './BranchPill';
 
 interface BannerData {
     visible: boolean;
@@ -142,6 +143,9 @@ export default function BannerEditor({ token, username, branchOverride, onBack }
                     <div>
                         <h2 className="text-xl font-bold text-white">Site Banner</h2>
                         <p className="text-sm text-gray-400 mt-1">Announcement shown at the top of every page.</p>
+                        <div className="mt-2">
+                            <BranchPill branch={branchOverride || 'main'} />
+                        </div>
                     </div>
                     {dirty && (
                         <button onClick={preparePublish} disabled={saving}

--- a/src/components/admin/BranchPill.tsx
+++ b/src/components/admin/BranchPill.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function BranchPill({ branch }: { branch: string }) {
+    return (
+        <span className="inline-flex items-center gap-1 text-xs text-gray-500 font-mono bg-white/[0.05] px-2 py-0.5 rounded-full">
+            <svg className="h-3 w-3" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
+            </svg>
+            {branch}
+        </span>
+    );
+}

--- a/src/components/admin/MarkdownEditor.tsx
+++ b/src/components/admin/MarkdownEditor.tsx
@@ -1,4 +1,8 @@
 import React, { useState, useRef, useCallback } from 'react';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+
+marked.setOptions({ gfm: true, breaks: true });
 
 function toKebab(str: string): string {
     return str
@@ -6,29 +10,6 @@ function toKebab(str: string): string {
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/(^-|-$)/g, '');
-}
-
-/**
- * Markdown → HTML for preview.
- * HTML entities are escaped FIRST, so user input cannot inject raw HTML.
- * This preview is only rendered inside the admin CMS (noindex, authenticated).
- */
-function mdToPreviewHtml(md: string): string {
-    return md
-        .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-        .replace(/^### (.+)$/gm, '<h3 class="text-lg font-semibold text-white mt-4 mb-2">$1</h3>')
-        .replace(/^## (.+)$/gm, '<h2 class="text-xl font-semibold text-white mt-5 mb-2">$1</h2>')
-        .replace(/^# (.+)$/gm, '<h1 class="text-2xl font-bold text-white mt-6 mb-3">$1</h1>')
-        .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-        .replace(/\*(.+?)\*/g, '<em>$1</em>')
-        .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img alt="$1" src="$2" class="rounded max-w-full my-2" />')
-        .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="text-accent underline">$1</a>')
-        .replace(/^- (.+)$/gm, '<li class="ml-4">$1</li>')
-        .replace(/(<li.*<\/li>\n?)+/g, (m) => `<ul class="list-disc my-2">${m}</ul>`)
-        .replace(/^&gt; (.+)$/gm, '<blockquote class="border-l-2 border-gray-600 pl-3 text-gray-400 my-2">$1</blockquote>')
-        .replace(/^---$/gm, '<hr class="border-gray-700 my-4" />')
-        .replace(/^(?!<[hupoblira])(.*\S.*)$/gm, '<p class="my-1.5">$1</p>')
-        .replace(/\n{2,}/g, '\n');
 }
 
 interface Props {
@@ -39,6 +20,7 @@ interface Props {
 
 export default function MarkdownEditor({ value, onChange, onFileUpload }: Props) {
     const [mode, setMode] = useState<'write' | 'preview' | 'split'>('write');
+    const [dragging, setDragging] = useState(false);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
     const insert = useCallback((before: string, after = '', placeholder = '') => {
@@ -56,27 +38,21 @@ export default function MarkdownEditor({ value, onChange, onFileUpload }: Props)
         });
     }, [value, onChange]);
 
-    const handleImageInsert = useCallback(() => {
-        const choice = prompt('Enter image URL, or type "upload" to choose a file:');
-        if (!choice) return;
-
-        if (choice.toLowerCase() === 'upload') {
-            const input = document.createElement('input');
-            input.type = 'file';
-            input.accept = 'image/*';
-            input.onchange = async () => {
-                const file = input.files?.[0];
-                if (!file || !onFileUpload) return;
-                const path = await onFileUpload(file);
-                insert(`![${toKebab(file.name.replace(/\.[^.]+$/, ''))}](${path})\n`);
-            };
-            input.click();
-        } else {
-            insert(`![alt text](${choice})\n`);
-        }
+    const handleImageUpload = useCallback(() => {
+        if (!onFileUpload) return;
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'image/*';
+        input.onchange = async () => {
+            const file = input.files?.[0];
+            if (!file) return;
+            const path = await onFileUpload(file);
+            insert(`![${toKebab(file.name.replace(/\.[^.]+$/, ''))}](${path})\n`);
+        };
+        input.click();
     }, [insert, onFileUpload]);
 
-    const handleFileInsert = useCallback(() => {
+    const handleFileUpload = useCallback(() => {
         if (!onFileUpload) return;
         const input = document.createElement('input');
         input.type = 'file';
@@ -90,42 +66,153 @@ export default function MarkdownEditor({ value, onChange, onFileUpload }: Props)
         input.click();
     }, [insert, onFileUpload]);
 
+    const handleDragOver = useCallback((e: React.DragEvent) => {
+        e.preventDefault();
+        setDragging(true);
+    }, []);
+
+    const handleDragLeave = useCallback(() => {
+        setDragging(false);
+    }, []);
+
+    const handleDrop = useCallback(async (e: React.DragEvent) => {
+        e.preventDefault();
+        setDragging(false);
+        if (!onFileUpload) return;
+        const file = e.dataTransfer.files?.[0];
+        if (!file) return;
+        if (file.type.startsWith('image/')) {
+            const path = await onFileUpload(file);
+            insert(`![${toKebab(file.name.replace(/\.[^.]+$/, ''))}](${path})\n`);
+        } else {
+            const path = await onFileUpload(file);
+            const name = toKebab(file.name.replace(/\.[^.]+$/, ''));
+            insert(`[${name}](${path})\n`);
+        }
+    }, [insert, onFileUpload]);
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        const mod = e.metaKey || e.ctrlKey;
+        if (mod && e.key === 'b') {
+            e.preventDefault();
+            insert('**', '**', 'bold');
+        } else if (mod && e.key === 'i') {
+            e.preventDefault();
+            insert('*', '*', 'italic');
+        } else if (mod && e.key === 'k') {
+            e.preventDefault();
+            insert('[', '](url)', 'link text');
+        } else if (e.key === 'Tab' && !e.shiftKey) {
+            e.preventDefault();
+            insert('  ');
+        } else if (e.key === 'Tab' && e.shiftKey) {
+            e.preventDefault();
+            const ta = e.currentTarget;
+            const start = ta.selectionStart;
+            const lineStart = value.lastIndexOf('\n', start - 1) + 1;
+            if (value.slice(lineStart, lineStart + 2) === '  ') {
+                const newValue = value.slice(0, lineStart) + value.slice(lineStart + 2);
+                onChange(newValue);
+                requestAnimationFrame(() => {
+                    ta.focus();
+                    ta.setSelectionRange(Math.max(start - 2, lineStart), Math.max(start - 2, lineStart));
+                });
+            }
+        }
+    }, [value, onChange, insert]);
+
+    const rawHtml = marked.parse(value) as string;
+    // DOMPurify sanitizes the marked output before rendering — safe against XSS
+    const previewHtml = DOMPurify.sanitize(rawHtml);
+
     const Btn = ({ onClick, active, title, children }: { onClick: () => void; active?: boolean; title: string; children: React.ReactNode }) => (
         <button
             type="button"
             onMouseDown={e => { e.preventDefault(); onClick(); }}
             title={title}
-            className={`p-1.5 rounded text-xs transition-colors ${active ? 'bg-accent/20 text-accent' : 'text-gray-400 hover:text-white hover:bg-white/5'}`}
+            className={`p-1.5 rounded transition-colors ${active ? 'bg-accent/20 text-accent' : 'text-gray-400 hover:text-white hover:bg-white/5'}`}
         >
             {children}
         </button>
     );
 
-    // Preview HTML is safe: mdToPreviewHtml escapes all HTML entities before applying markdown transforms
-    const previewHtml = mdToPreviewHtml(value);
+    const Sep = () => <div className="w-px h-5 bg-gray-600 mx-0.5" />;
+
+    const icon = (d: string) => (
+        <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d={d} />
+        </svg>
+    );
 
     return (
         <div className="rounded-lg border border-gray-600 overflow-hidden">
             {/* Toolbar */}
             <div className="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-600 bg-dark-surface flex-wrap">
-                <Btn onClick={() => insert('**', '**', 'bold')} title="Bold"><span className="font-bold text-[11px]">B</span></Btn>
-                <Btn onClick={() => insert('*', '*', 'italic')} title="Italic"><span className="italic text-[11px]">I</span></Btn>
-                <div className="w-px h-5 bg-gray-600 mx-1" />
-                <Btn onClick={() => insert('# ', '', 'Heading')} title="H1"><span className="font-bold text-[11px]">H1</span></Btn>
-                <Btn onClick={() => insert('## ', '', 'Heading')} title="H2"><span className="font-bold text-[11px]">H2</span></Btn>
-                <Btn onClick={() => insert('### ', '', 'Heading')} title="H3"><span className="font-bold text-[11px]">H3</span></Btn>
-                <div className="w-px h-5 bg-gray-600 mx-1" />
-                <Btn onClick={() => insert('- ', '', 'item')} title="Bullet list"><span className="text-[11px]">List</span></Btn>
-                <Btn onClick={() => insert('[', '](url)', 'link text')} title="Link"><span className="text-[11px]">Link</span></Btn>
-                <Btn onClick={handleImageInsert} title="Image (URL or upload)"><span className="text-[11px]">Img</span></Btn>
-                {onFileUpload && <Btn onClick={handleFileInsert} title="Upload file"><span className="text-[11px]">File</span></Btn>}
-                <Btn onClick={() => insert('> ', '', 'quote')} title="Blockquote"><span className="text-[11px]">Quote</span></Btn>
-                <Btn onClick={() => insert('\n---\n')} title="Horizontal rule"><span className="text-[11px]">HR</span></Btn>
+                <Btn onClick={() => insert('**', '**', 'bold')} title="Bold (Ctrl+B)">
+                    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6 4h8a4 4 0 0 1 2.82 6.83A4 4 0 0 1 15 18H6V4zm3 7h5a1.5 1.5 0 0 0 0-3H9v3zm0 3v3h6a1.5 1.5 0 0 0 0-3H9z"/></svg>
+                </Btn>
+                <Btn onClick={() => insert('*', '*', 'italic')} title="Italic (Ctrl+I)">
+                    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M10 4h8l-1 2h-2.6l-4 12H13l-1 2H4l1-2h2.6l4-12H9l1-2z"/></svg>
+                </Btn>
+                <Btn onClick={() => insert('~~', '~~', 'strikethrough')} title="Strikethrough">
+                    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3 12h18v2H3v-2zm3-7h12v2H6V5zm2 14h8v-2H8v2z"/></svg>
+                </Btn>
+                <Sep />
+                <Btn onClick={() => insert('# ', '', 'Heading')} title="Heading 1">
+                    <span className="font-bold text-xs leading-none">H1</span>
+                </Btn>
+                <Btn onClick={() => insert('## ', '', 'Heading')} title="Heading 2">
+                    <span className="font-bold text-xs leading-none">H2</span>
+                </Btn>
+                <Btn onClick={() => insert('### ', '', 'Heading')} title="Heading 3">
+                    <span className="font-bold text-xs leading-none">H3</span>
+                </Btn>
+                <Sep />
+                <Btn onClick={() => insert('- ', '', 'item')} title="Bullet list">
+                    {icon('M8.25 6.75h12M8.25 12h12M8.25 17.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z')}
+                </Btn>
+                <Btn onClick={() => insert('1. ', '', 'item')} title="Numbered list">
+                    {icon('M3.75 5.25h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5m-16.5 4.5h16.5')}
+                </Btn>
+                <Sep />
+                <Btn onClick={() => insert('[', '](url)', 'link text')} title="Link (Ctrl+K)">
+                    {icon('M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244')}
+                </Btn>
+                <Btn onClick={handleImageUpload} title="Upload image">
+                    {icon('m2.25 15.75 5.159-5.159a2.25 2.25 0 0 1 3.182 0l5.159 5.159m-1.5-1.5 1.409-1.409a2.25 2.25 0 0 1 3.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0 0 22.5 18.75V5.25A2.25 2.25 0 0 0 20.25 3H3.75A2.25 2.25 0 0 0 1.5 5.25v13.5A2.25 2.25 0 0 0 3.75 21Z')}
+                </Btn>
+                {onFileUpload && (
+                    <Btn onClick={handleFileUpload} title="Upload file">
+                        {icon('M18.375 12.739l-7.693 7.693a4.5 4.5 0 01-6.364-6.364l10.94-10.94A3 3 0 1119.5 7.372L8.552 18.32m.009-.01l-.01.01m5.699-9.941l-7.81 7.81a1.5 1.5 0 002.112 2.13')}
+                    </Btn>
+                )}
+                <Sep />
+                <Btn onClick={() => insert('`', '`', 'code')} title="Inline code">
+                    {icon('M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5')}
+                </Btn>
+                <Btn onClick={() => insert('\n```\n', '\n```\n', 'code block')} title="Code block">
+                    {icon('M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0021 18V6a2.25 2.25 0 00-2.25-2.25H5.25A2.25 2.25 0 003 6v12a2.25 2.25 0 002.25 2.25z')}
+                </Btn>
+                <Btn onClick={() => insert('> ', '', 'quote')} title="Blockquote">
+                    {icon('M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z')}
+                </Btn>
+                <Btn onClick={() => insert('\n---\n')} title="Horizontal rule">
+                    {icon('M5 12h14')}
+                </Btn>
+                <Btn onClick={() => insert('\n| Column 1 | Column 2 | Column 3 |\n| --- | --- | --- |\n| cell | cell | cell |\n')} title="Insert table">
+                    {icon('M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 0 1-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0 1 12 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M12 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M21 12c0 .621-.504 1.125-1.125 1.125m-5.25 0c.621 0 1.125.504 1.125 1.125m-12.75-1.125c-.621 0-1.125.504-1.125 1.125m0 1.5v-1.5m0 0c0-.621.504-1.125 1.125-1.125m0 0h7.5')}
+                </Btn>
 
                 <div className="ml-auto flex gap-0.5">
-                    <Btn onClick={() => setMode('write')} active={mode === 'write'} title="Source"><span className="text-[11px]">Source</span></Btn>
-                    <Btn onClick={() => setMode('split')} active={mode === 'split'} title="Split view"><span className="text-[11px]">Split</span></Btn>
-                    <Btn onClick={() => setMode('preview')} active={mode === 'preview'} title="Preview"><span className="text-[11px]">Preview</span></Btn>
+                    <Btn onClick={() => setMode('write')} active={mode === 'write'} title="Source">
+                        {icon('m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10')}
+                    </Btn>
+                    <Btn onClick={() => setMode('split')} active={mode === 'split'} title="Split view">
+                        {icon('M9 4.5v15m6-15v15M4.5 19.5h15a1.5 1.5 0 0 0 1.5-1.5V6a1.5 1.5 0 0 0-1.5-1.5h-15A1.5 1.5 0 0 0 3 6v12a1.5 1.5 0 0 0 1.5 1.5Z')}
+                    </Btn>
+                    <Btn onClick={() => setMode('preview')} active={mode === 'preview'} title="Preview">
+                        {icon('M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178ZM15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z')}
+                    </Btn>
                 </div>
             </div>
 
@@ -136,13 +223,20 @@ export default function MarkdownEditor({ value, onChange, onFileUpload }: Props)
                         ref={textareaRef}
                         value={value}
                         onChange={e => onChange(e.target.value)}
-                        className="w-full min-h-[350px] px-4 py-3 text-sm font-mono bg-[#1a1a2e] text-gray-200 focus:outline-none resize-y"
-                        placeholder="Write markdown here..."
+                        onKeyDown={handleKeyDown}
+                        onDragOver={handleDragOver}
+                        onDragLeave={handleDragLeave}
+                        onDrop={handleDrop}
+                        className={`w-full min-h-[350px] px-4 py-3 text-sm font-mono bg-[#1a1a2e] text-gray-200 focus:outline-none resize-y transition-colors ${
+                            dragging ? 'ring-2 ring-accent ring-inset bg-accent/5' : ''
+                        }`}
+                        placeholder="Write markdown here... (drop images to upload)"
                     />
                 )}
                 {mode !== 'write' && (
                     <div
-                        className="min-h-[350px] px-4 py-3 text-sm bg-dark-surface text-gray-300 overflow-y-auto"
+                        className="cms-preview min-h-[350px] px-4 py-3 text-sm bg-dark-surface text-gray-300 overflow-y-auto"
+                        // previewHtml is sanitized by DOMPurify above — safe to render
                         dangerouslySetInnerHTML={{ __html: previewHtml }}
                     />
                 )}

--- a/src/components/admin/OpenPRsView.tsx
+++ b/src/components/admin/OpenPRsView.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useState } from 'react';
+import { listUserPRs, getPRFiles, type PullRequest, type PRFile } from './github';
+import { detectCollection, type Collection } from './schema';
+
+function timeAgo(dateStr: string): string {
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const minutes = Math.floor(diff / 60_000);
+    if (minutes < 1) return 'just now';
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+}
+
+interface PRCardData {
+    pr: PullRequest;
+    collection: Collection | null;
+    files: PRFile[];
+}
+
+export default function OpenPRsView({
+    token,
+    username,
+    onEditPR,
+    onCountLoaded,
+}: {
+    token: string;
+    username: string;
+    onEditPR: (pr: PullRequest, collection: Collection, files: PRFile[]) => void;
+    onCountLoaded: (count: number) => void;
+}) {
+    const [cards, setCards] = useState<PRCardData[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!username) return;
+
+        setLoading(true);
+        setError(null);
+
+        (async () => {
+            try {
+                const prs = await listUserPRs(token, username);
+                const results: PRCardData[] = await Promise.all(
+                    prs.map(async (pr) => {
+                        const files = await getPRFiles(token, pr.number);
+                        const collection = detectCollection(files.map(f => f.filename));
+                        return { pr, collection, files };
+                    }),
+                );
+                setCards(results);
+                onCountLoaded(results.length);
+            } catch (err) {
+                setError(err instanceof Error ? err.message : 'Failed to load pull requests.');
+                onCountLoaded(0);
+            } finally {
+                setLoading(false);
+            }
+        })();
+    }, [token, username]);
+
+    if (loading) {
+        return (
+            <div className="flex-1 flex flex-col items-center justify-center py-20">
+                <svg className="h-7 w-7 animate-spin text-accent" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                </svg>
+                <span className="text-xs text-gray-500 mt-3">Loading pull requests...</span>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="flex-1 p-6 sm:p-8">
+                <div className="rounded-xl border border-red-800/40 bg-red-900/10 p-5">
+                    <p className="text-sm text-red-400">{error}</p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex-1 p-6 sm:p-8 overflow-y-auto">
+            <div className="flex items-center justify-between mb-6">
+                <h2 className="text-xl font-bold text-white">Pull Requests</h2>
+                <span className="text-sm text-gray-500">{cards.length} open</span>
+            </div>
+
+            {cards.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-20 text-center">
+                    <svg className="h-10 w-10 text-gray-700 mb-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden="true">
+                        <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
+                    </svg>
+                    <p className="text-sm text-gray-500">No open pull requests.</p>
+                    <p className="text-xs text-gray-600 mt-1">Edits you save will appear here for review.</p>
+                </div>
+            ) : (
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                    {cards.map(({ pr, collection, files }) => {
+                        const isDisabled = collection === null;
+                        const branchShort = pr.head.ref.replace(/^cms\/[^/]+\/\d+-/, '');
+
+                        return (
+                            <button
+                                key={pr.number}
+                                onClick={() => !isDisabled && onEditPR(pr, collection!, files)}
+                                disabled={isDisabled}
+                                className={`text-left rounded-xl border border-gray-700/30 bg-white/[0.03] p-4 transition-colors ${
+                                    isDisabled
+                                        ? 'opacity-50 cursor-not-allowed'
+                                        : 'hover:border-accent/40 hover:bg-white/[0.05]'
+                                }`}
+                            >
+                                <div className="flex items-start justify-between gap-2 mb-2">
+                                    <span className="text-sm font-semibold text-white leading-snug line-clamp-2">
+                                        {pr.title}
+                                    </span>
+                                    {collection ? (
+                                        <span className="shrink-0 rounded-full bg-accent/10 text-accent px-2 py-0.5 text-xs font-medium">
+                                            {collection.label}
+                                        </span>
+                                    ) : (
+                                        <span className="shrink-0 rounded-full bg-gray-700/50 text-gray-500 px-2 py-0.5 text-xs font-medium">
+                                            Unknown
+                                        </span>
+                                    )}
+                                </div>
+
+                                <div className="flex items-center gap-2 flex-wrap text-xs text-gray-500 mt-3">
+                                    <span>#{pr.number}</span>
+                                    <span className="text-gray-700">·</span>
+                                    <span>{timeAgo(pr.created_at)}</span>
+                                    <span className="text-gray-700">·</span>
+                                    <span>{files.length} {files.length === 1 ? 'file' : 'files'}</span>
+                                </div>
+
+                                <div className="mt-2 text-xs text-gray-600 font-mono truncate" title={pr.head.ref}>
+                                    {branchShort}
+                                </div>
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/components/admin/PeopleEditor.tsx
+++ b/src/components/admin/PeopleEditor.tsx
@@ -271,13 +271,8 @@ export default function PeopleEditor({ token, username, branchOverride, onBack }
         setConfirmDialog(null);
         setSaving(true);
         try {
-            if (branchOverride) {
-                await commitToBranch(token, branchOverride, confirmDialog.files);
-                setResult({ prUrl: '', branch: branchOverride });
-            } else {
-                const res = await saveAsPR(token, { title: prTitle, description: prDescription, username, files: confirmDialog.files });
-                setResult(res);
-            }
+            const res = await saveAsPR(token, { title: prTitle, description: prDescription, username, files: confirmDialog.files });
+            setResult(res);
         } catch (err) {
             alert(`Save failed: ${err}`);
         }

--- a/src/components/admin/PeopleEditor.tsx
+++ b/src/components/admin/PeopleEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { readJsonFile, saveAsPR, type SaveResult } from './github';
+import { readJsonFile, readFileFromRef, saveAsPR, commitToBranch, type SaveResult } from './github';
 import { ELIXIR_GROUPS, ORG_KEYS, type PeopleData, type Person, type ElixirGroup } from './schema';
 import PRConfirmDialog from './PRConfirmDialog';
 
@@ -152,7 +152,7 @@ function PersonForm({
     );
 }
 
-export default function PeopleEditor({ token, username }: { token: string; username: string }) {
+export default function PeopleEditor({ token, username, branchOverride, onBack }: { token: string; username: string; branchOverride?: string; onBack?: () => void }) {
     const [data, setData] = useState<PeopleData | null>(null);
     const [loading, setLoading] = useState(true);
     const [editing, setEditing] = useState<{ orgKey: string; index: number } | 'new' | null>(null);
@@ -163,11 +163,17 @@ export default function PeopleEditor({ token, username }: { token: string; usern
 
     useEffect(() => {
         (async () => {
-            const d = await readJsonFile<PeopleData>(token, 'src/data/people.json');
+            let d: PeopleData;
+            if (branchOverride) {
+                const raw = await readFileFromRef(token, 'src/data/people.json', branchOverride);
+                d = JSON.parse(raw);
+            } else {
+                d = await readJsonFile<PeopleData>(token, 'src/data/people.json');
+            }
             setData(d);
             setLoading(false);
         })();
-    }, [token]);
+    }, [token, branchOverride]);
 
     const totalPeople = data ? Object.values(data.orgs).reduce((s, o) => s + o.people.length, 0) : 0;
 
@@ -226,20 +232,36 @@ export default function PeopleEditor({ token, username }: { token: string; usern
         setDeleteConfirm(null);
         setSaving(true);
         try {
-            const res = await saveAsPR(token, { title: prTitle, description: prDescription, username, files: deleteConfirm.files });
-            setResult(res);
+            if (branchOverride) {
+                await commitToBranch(token, branchOverride, deleteConfirm.files);
+                setResult({ prUrl: '', branch: branchOverride });
+            } else {
+                const res = await saveAsPR(token, { title: prTitle, description: prDescription, username, files: deleteConfirm.files });
+                setResult(res);
+            }
         } catch (err) {
             alert(`Save failed: ${err}`);
         }
         setSaving(false);
     };
 
-    const preparePublish = () => {
+    const preparePublish = async () => {
         if (!data) return;
         const files: Array<{ path: string; content: string; encoding?: 'utf-8' | 'base64' }> = [];
         files.push({ path: 'src/data/people.json', content: JSON.stringify(data, null, 2) + '\n' });
         for (const img of pendingImages) {
             if (img.base64) files.push({ path: img.path, content: img.base64, encoding: 'base64' });
+        }
+        if (branchOverride) {
+            setSaving(true);
+            try {
+                await commitToBranch(token, branchOverride, files);
+                setResult({ prUrl: '', branch: branchOverride });
+            } catch (err) {
+                alert(`Save failed: ${err}`);
+            }
+            setSaving(false);
+            return;
         }
         setConfirmDialog({ files });
     };
@@ -249,8 +271,13 @@ export default function PeopleEditor({ token, username }: { token: string; usern
         setConfirmDialog(null);
         setSaving(true);
         try {
-            const res = await saveAsPR(token, { title: prTitle, description: prDescription, username, files: confirmDialog.files });
-            setResult(res);
+            if (branchOverride) {
+                await commitToBranch(token, branchOverride, confirmDialog.files);
+                setResult({ prUrl: '', branch: branchOverride });
+            } else {
+                const res = await saveAsPR(token, { title: prTitle, description: prDescription, username, files: confirmDialog.files });
+                setResult(res);
+            }
         } catch (err) {
             alert(`Save failed: ${err}`);
         }
@@ -264,12 +291,21 @@ export default function PeopleEditor({ token, username }: { token: string; usern
                     <div className="h-12 w-12 mx-auto mb-4 rounded-full bg-green-900/20 flex items-center justify-center">
                         <svg className="h-6 w-6 text-green-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
                     </div>
-                    <h3 className="text-lg font-bold text-white mb-2">Pull request created</h3>
+                    <h3 className="text-lg font-bold text-white mb-2">{branchOverride ? 'Changes pushed' : 'Pull request created'}</h3>
                     <p className="text-sm text-gray-400 mb-6">People directory updated.</p>
-                    <a href={result.prUrl} target="_blank" rel="noopener noreferrer"
-                        className="px-4 py-2 text-sm font-semibold rounded-lg bg-accent text-white hover:opacity-90 transition-opacity">
-                        View PR on GitHub
-                    </a>
+                    <div className="flex items-center justify-center gap-3">
+                        {result.prUrl && (
+                            <a href={result.prUrl} target="_blank" rel="noopener noreferrer"
+                                className="px-4 py-2 text-sm font-semibold rounded-lg bg-accent text-white hover:opacity-90 transition-opacity">
+                                View PR on GitHub
+                            </a>
+                        )}
+                        {onBack && (
+                            <button onClick={onBack} className="px-4 py-2 text-sm font-semibold rounded-lg border border-gray-600 text-gray-300 hover:bg-white/5 transition-colors">
+                                Back to Pull Requests
+                            </button>
+                        )}
+                    </div>
                 </div>
             </div>
         );
@@ -322,6 +358,12 @@ export default function PeopleEditor({ token, username }: { token: string; usern
 
     return (
         <div className="flex-1 p-6 sm:p-8 overflow-y-auto">
+            {onBack && (
+                <button onClick={onBack} className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-white mb-6 transition-colors">
+                    <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" /></svg>
+                    Back to Pull Requests
+                </button>
+            )}
             <div className="flex items-center justify-between mb-6">
                 <div>
                     <h2 className="text-xl font-bold text-white">People</h2>
@@ -336,7 +378,7 @@ export default function PeopleEditor({ token, username }: { token: string; usern
                     {pendingImages.length > 0 && (
                         <button onClick={preparePublish} disabled={saving}
                             className="px-4 py-2 text-sm font-semibold rounded-lg bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 transition-colors">
-                            {saving ? 'Saving...' : `Publish Changes (${pendingImages.length} new)`}
+                            {saving ? 'Saving...' : branchOverride ? 'Push to PR' : `Publish Changes (${pendingImages.length} new)`}
                         </button>
                     )}
                 </div>

--- a/src/components/admin/PeopleEditor.tsx
+++ b/src/components/admin/PeopleEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { readJsonFile, readFileFromRef, saveAsPR, commitToBranch, type SaveResult } from './github';
 import { ELIXIR_GROUPS, ORG_KEYS, type PeopleData, type Person, type ElixirGroup } from './schema';
 import PRConfirmDialog from './PRConfirmDialog';
+import BranchPill from './BranchPill';
 
 const ORG_LABELS: Record<string, string> = {
     uib: 'University of Bergen', uio: 'University of Oslo',
@@ -363,6 +364,9 @@ export default function PeopleEditor({ token, username, branchOverride, onBack }
                 <div>
                     <h2 className="text-xl font-bold text-white">People</h2>
                     <p className="text-sm text-gray-400">{totalPeople} members across {Object.keys(data!.orgs).length} organizations</p>
+                    <div className="mt-2">
+                        <BranchPill branch={branchOverride || 'main'} />
+                    </div>
                 </div>
                 <div className="flex gap-2">
                     <button onClick={() => setEditing('new')}

--- a/src/components/admin/SlidesEditor.tsx
+++ b/src/components/admin/SlidesEditor.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { readJsonFile, saveAsPR, type SaveResult } from './github';
+import { readJsonFile, readFileFromRef, saveAsPR, commitToBranch, type SaveResult } from './github';
 import type { Slide } from './schema';
 import PRConfirmDialog from './PRConfirmDialog';
 
 interface PendingImage { file: File; base64?: string; path: string }
 
-export default function SlidesEditor({ token, username }: { token: string; username: string }) {
+export default function SlidesEditor({ token, username, branchOverride, onBack }: { token: string; username: string; branchOverride?: string; onBack?: () => void }) {
     const [slides, setSlides] = useState<Slide[]>([]);
     const [loading, setLoading] = useState(true);
     const [editing, setEditing] = useState<number | 'new' | null>(null);
@@ -17,11 +17,17 @@ export default function SlidesEditor({ token, username }: { token: string; usern
 
     useEffect(() => {
         (async () => {
-            const d = await readJsonFile<Slide[]>(token, 'src/data/slides.json');
+            let d: Slide[];
+            if (branchOverride) {
+                const raw = await readFileFromRef(token, 'src/data/slides.json', branchOverride);
+                d = JSON.parse(raw);
+            } else {
+                d = await readJsonFile<Slide[]>(token, 'src/data/slides.json');
+            }
             setSlides(d);
             setLoading(false);
         })();
-    }, [token]);
+    }, [token, branchOverride]);
 
     const moveUp = (i: number) => {
         if (i === 0) return;
@@ -68,11 +74,22 @@ export default function SlidesEditor({ token, username }: { token: string; usern
         setEditing(null);
     };
 
-    const preparePublish = () => {
+    const preparePublish = async () => {
         const files: Array<{ path: string; content: string; encoding?: 'utf-8' | 'base64' }> = [];
         files.push({ path: 'src/data/slides.json', content: JSON.stringify(slides, null, 4) + '\n' });
         for (const img of pendingImages) {
             if (img.base64) files.push({ path: img.path, content: img.base64, encoding: 'base64' });
+        }
+        if (branchOverride) {
+            setSaving(true);
+            try {
+                await commitToBranch(token, branchOverride, files);
+                setResult({ prUrl: '', branch: branchOverride });
+            } catch (err) {
+                alert(`Save failed: ${err}`);
+            }
+            setSaving(false);
+            return;
         }
         setConfirmDialog({ files });
     };
@@ -97,12 +114,21 @@ export default function SlidesEditor({ token, username }: { token: string; usern
                     <div className="h-12 w-12 mx-auto mb-4 rounded-full bg-green-900/20 flex items-center justify-center">
                         <svg className="h-6 w-6 text-green-400" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
                     </div>
-                    <h3 className="text-lg font-bold text-white mb-2">Pull request created</h3>
+                    <h3 className="text-lg font-bold text-white mb-2">{branchOverride ? 'Changes pushed' : 'Pull request created'}</h3>
                     <p className="text-sm text-gray-400 mb-6">Carousel slides updated.</p>
-                    <a href={result.prUrl} target="_blank" rel="noopener noreferrer"
-                        className="px-4 py-2 text-sm font-semibold rounded-lg bg-accent text-white hover:opacity-90 transition-opacity">
-                        View PR on GitHub
-                    </a>
+                    <div className="flex items-center justify-center gap-3">
+                        {result.prUrl && (
+                            <a href={result.prUrl} target="_blank" rel="noopener noreferrer"
+                                className="px-4 py-2 text-sm font-semibold rounded-lg bg-accent text-white hover:opacity-90 transition-opacity">
+                                View PR on GitHub
+                            </a>
+                        )}
+                        {onBack && (
+                            <button onClick={onBack} className="px-4 py-2 text-sm font-semibold rounded-lg border border-gray-600 text-gray-300 hover:bg-white/5 transition-colors">
+                                Back to Pull Requests
+                            </button>
+                        )}
+                    </div>
                 </div>
             </div>
         );
@@ -143,6 +169,12 @@ export default function SlidesEditor({ token, username }: { token: string; usern
 
     return (
         <div className="flex-1 p-6 sm:p-8 overflow-y-auto">
+            {onBack && (
+                <button onClick={onBack} className="inline-flex items-center gap-1.5 text-sm text-gray-400 hover:text-white mb-6 transition-colors">
+                    <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" /></svg>
+                    Back to Pull Requests
+                </button>
+            )}
             <div className="flex items-center justify-between mb-6">
                 <div>
                     <h2 className="text-xl font-bold text-white">Slides</h2>
@@ -157,7 +189,7 @@ export default function SlidesEditor({ token, username }: { token: string; usern
                     {dirty && (
                         <button onClick={preparePublish} disabled={saving}
                             className="px-4 py-2 text-sm font-semibold rounded-lg bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 transition-colors">
-                            {saving ? 'Saving...' : 'Publish Changes'}
+                            {saving ? 'Saving...' : branchOverride ? 'Push to PR' : 'Publish Changes'}
                         </button>
                     )}
                 </div>

--- a/src/components/admin/SlidesEditor.tsx
+++ b/src/components/admin/SlidesEditor.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { readJsonFile, readFileFromRef, saveAsPR, commitToBranch, type SaveResult } from './github';
 import type { Slide } from './schema';
 import PRConfirmDialog from './PRConfirmDialog';
+import BranchPill from './BranchPill';
 
 interface PendingImage { file: File; base64?: string; path: string }
 
@@ -179,6 +180,9 @@ export default function SlidesEditor({ token, username, branchOverride, onBack }
                 <div>
                     <h2 className="text-xl font-bold text-white">Slides</h2>
                     <p className="text-sm text-gray-400">{slides.length} slides in the highlights carousel</p>
+                    <div className="mt-2">
+                        <BranchPill branch={branchOverride || 'main'} />
+                    </div>
                 </div>
                 <div className="flex gap-2">
                     <button onClick={() => setEditing('new')}

--- a/src/components/admin/github.ts
+++ b/src/components/admin/github.ts
@@ -163,6 +163,7 @@ export async function listUserPRs(token: string, username: string): Promise<Pull
         `${API}/repos/${REPO_OWNER}/${REPO_NAME}/pulls?state=open&per_page=100`,
         { headers: headers(token) },
     );
+    if (!res.ok) throw new Error(`Failed to fetch pull requests: ${res.status}`);
     const prs: PullRequest[] = await res.json();
     const filtered = prs.filter(
         pr => pr.head.ref.startsWith(`cms/${username}/`),
@@ -182,6 +183,7 @@ export async function getPRFiles(token: string, prNumber: number): Promise<PRFil
         `${API}/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${prNumber}/files`,
         { headers: headers(token) },
     );
+    if (!res.ok) throw new Error(`Failed to fetch PR files: ${res.status}`);
     return res.json();
 }
 
@@ -191,6 +193,7 @@ export async function readFileFromRef(token: string, path: string, ref: string):
         `${API}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${path}?ref=${ref}`,
         { headers: headers(token) },
     );
+    if (!res.ok) throw new Error(`Failed to read ${path} from ${ref}: ${res.status}`);
     const data = await res.json();
     return b64Decode(data.content);
 }
@@ -215,11 +218,15 @@ export async function commitToBranch(
         };
         if (existingSha) body.sha = existingSha;
 
-        await fetch(`${API}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${file.path}`, {
+        const putRes = await fetch(`${API}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${file.path}`, {
             method: 'PUT',
             headers: headers(token),
             body: JSON.stringify(body),
         });
+        if (!putRes.ok) {
+            const err = await putRes.json().catch(() => ({}));
+            throw new Error(`Failed to commit ${file.path}: ${putRes.status} ${err.message || ''}`);
+        }
     }
 
     cacheClear();

--- a/src/components/admin/github.ts
+++ b/src/components/admin/github.ts
@@ -146,6 +146,85 @@ export async function getUser(token: string): Promise<{ login: string; avatar_ur
     return user;
 }
 
+export interface PullRequest {
+    number: number;
+    title: string;
+    created_at: string;
+    head: { ref: string; sha: string };
+    html_url: string;
+}
+
+/** List open PRs created by the logged-in user on cms/ branches */
+export async function listUserPRs(token: string, username: string): Promise<PullRequest[]> {
+    const cached = cacheGet<PullRequest[]>(`prs:${username}`);
+    if (cached) return cached;
+
+    const res = await fetch(
+        `${API}/repos/${REPO_OWNER}/${REPO_NAME}/pulls?state=open&per_page=100`,
+        { headers: headers(token) },
+    );
+    const prs: PullRequest[] = await res.json();
+    const filtered = prs.filter(
+        pr => pr.head.ref.startsWith(`cms/${username}/`),
+    );
+    cacheSet(`prs:${username}`, filtered);
+    return filtered;
+}
+
+export interface PRFile {
+    filename: string;
+    status: string;
+}
+
+/** Get the list of changed files in a PR */
+export async function getPRFiles(token: string, prNumber: number): Promise<PRFile[]> {
+    const res = await fetch(
+        `${API}/repos/${REPO_OWNER}/${REPO_NAME}/pulls/${prNumber}/files`,
+        { headers: headers(token) },
+    );
+    return res.json();
+}
+
+/** Read a file from a specific branch/ref (not cached — always fresh) */
+export async function readFileFromRef(token: string, path: string, ref: string): Promise<string> {
+    const res = await fetch(
+        `${API}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${path}?ref=${ref}`,
+        { headers: headers(token) },
+    );
+    const data = await res.json();
+    return b64Decode(data.content);
+}
+
+/** Commit files to an existing branch (updates an open PR) */
+export async function commitToBranch(
+    token: string,
+    branch: string,
+    files: Array<{ path: string; content: string; encoding?: 'utf-8' | 'base64' }>,
+): Promise<void> {
+    for (const file of files) {
+        const shaRes = await fetch(
+            `${API}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${file.path}?ref=${branch}`,
+            { headers: headers(token) },
+        );
+        const existingSha = shaRes.ok ? (await shaRes.json()).sha : null;
+
+        const body: Record<string, unknown> = {
+            message: `content: update ${file.path}`,
+            content: file.encoding === 'base64' ? file.content : b64Encode(file.content),
+            branch,
+        };
+        if (existingSha) body.sha = existingSha;
+
+        await fetch(`${API}/repos/${REPO_OWNER}/${REPO_NAME}/contents/${file.path}`, {
+            method: 'PUT',
+            headers: headers(token),
+            body: JSON.stringify(body),
+        });
+    }
+
+    cacheClear();
+}
+
 /** Check if user has write access to the repo (cached) */
 export async function hasWriteAccess(token: string): Promise<boolean> {
     const cached = cacheGet<boolean>('access');

--- a/src/components/admin/schema.ts
+++ b/src/components/admin/schema.ts
@@ -135,6 +135,18 @@ export function getCollection(name: string): Collection | undefined {
     return collections.find(c => c.name === name);
 }
 
+/** Detect which collection a set of file paths belongs to */
+export function detectCollection(filePaths: string[]): Collection | null {
+    for (const c of collections) {
+        if (c.kind === 'content') {
+            if (filePaths.some(p => p.startsWith(c.folder + '/'))) return c;
+        } else {
+            if (filePaths.some(p => p === c.file)) return c;
+        }
+    }
+    return null;
+}
+
 // ─── People data types ───────────────────────────────────
 
 export interface ElixirGroup {

--- a/src/components/admin/schema.ts
+++ b/src/components/admin/schema.ts
@@ -45,7 +45,7 @@ export const collections: Collection[] = [
         folder: 'src/content/news',
         canCreate: true,
         depth: 2,
-        layoutPath: '../../../layouts/page.astro',
+        layoutPath: '../../../../layouts/page.astro',
         description: 'News articles published on elixir.no/news. Each article has a title, date, summary, optional cover image, tags for filtering, and author usernames that link to the people directory. Articles are organized by year.',
         fields: [
             { name: 'title', label: 'Title', type: 'string', required: true },
@@ -63,7 +63,7 @@ export const collections: Collection[] = [
         folder: 'src/content/events',
         canCreate: true,
         depth: 2,
-        layoutPath: '../../../layouts/page.astro',
+        layoutPath: '../../../../layouts/page.astro',
         description: 'Events listed on elixir.no/events. Upcoming events appear first, past events below. Each event needs a title, date, summary, and optional cover image. Events are organized by year.',
         fields: [
             { name: 'title', label: 'Title', type: 'string', required: true },

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -135,3 +135,62 @@
 .tess-search button {
   @apply bg-brand-primary text-white px-4 py-2 rounded-lg font-semibold hover:bg-brand-primary focus:ring-2 focus:ring-brand-primary !important;
 }
+
+/* ─── CMS Preview styles ──────────────────────────────── */
+
+.cms-preview {
+  h1 { @apply text-2xl font-bold text-white mt-6 mb-3; }
+  h2 { @apply text-xl font-semibold text-white mt-5 mb-2; }
+  h3 { @apply text-lg font-semibold text-white mt-4 mb-2; }
+  h4 { @apply text-base font-semibold text-white mt-3 mb-1; }
+
+  p { @apply my-2 leading-relaxed; }
+
+  a { @apply text-accent underline; }
+
+  strong { @apply font-semibold text-white; }
+
+  del { @apply line-through text-gray-500; }
+
+  ul { @apply list-disc ml-5 my-2; }
+  ol { @apply list-decimal ml-5 my-2; }
+  li { @apply my-0.5; }
+
+  blockquote {
+    @apply border-l-2 border-gray-600 pl-3 text-gray-400 my-3;
+  }
+
+  hr { @apply border-gray-700 my-4; }
+
+  code {
+    @apply bg-gray-800 px-1.5 py-0.5 rounded text-sm font-mono text-gray-300;
+  }
+
+  pre {
+    @apply bg-gray-800 rounded-lg p-3 my-3 overflow-x-auto;
+
+    code {
+      @apply bg-transparent p-0 rounded-none;
+    }
+  }
+
+  table {
+    @apply w-full my-3 text-sm;
+
+    th {
+      @apply text-left px-3 py-2 border border-gray-600 bg-white/[0.05] text-gray-300 font-semibold;
+    }
+
+    td {
+      @apply px-3 py-2 border border-gray-700/50 text-gray-400;
+    }
+  }
+
+  img {
+    @apply rounded max-w-full my-2;
+  }
+
+  input[type="checkbox"] {
+    @apply mr-1.5;
+  }
+}


### PR DESCRIPTION
## Summary

### PR Dashboard
- Default landing view after login shows user's open CMS pull requests as cards
- Cards show title, collection badge, time ago, branch name, file count
- Click a card to load PR content into the matching editor
- Saves push to the existing PR branch (no new PR created)

### Lazy Loading
- Collection entries load in batches of 5 (was: all at once, 50+ API calls)
- "Show more (N remaining)" button to load next batch on demand

### Branch Indicator
- All editors show a `main` branch pill below the heading
- When editing a PR, shows the PR branch name instead

### Rich Markdown Editor
- Preview powered by `marked` (GFM) + `DOMPurify` — replaces fragile regex parser
- SVG toolbar icons (was: text labels)
- New formatting: strikethrough, numbered list, inline code, code block, table
- Drag-and-drop image upload with visual feedback
- Image button opens file picker directly (was: `prompt()` dialog)
- Keyboard shortcuts: Ctrl+B, Ctrl+I, Ctrl+K, Tab/Shift+Tab
- Styled preview pane (headings, code blocks, tables, lists, blockquotes)

### Bug Fix
- Fixed `layoutPath` for depth-2 collections (news, events) — was 3 levels, needs 4

## Test plan

- [x] Login to `/admin` — PR list is the default view
- [x] Click News — shows 5 entries with "Show more" button and `main` branch pill
- [x] Click "Show more" — next 5 load
- [x] Create a news article via CMS — PR appears in the PR list
- [x] Click the PR card — editor opens with PR content, branch pill shows PR branch
- [x] Edit and save — commit lands on existing branch
- [x] Markdown editor: test bold, italic, headings, code, table, strikethrough
- [x] Markdown editor: drag-drop an image, use Ctrl+B/I/K shortcuts
- [x] Preview mode: headings, code blocks, tables render with proper styling
- [x] Build passes: `pnpm build`