### PR TITLE
fix(admin): correct CMS layout path for services & funding (#289)

### DIFF
--- a/src/components/admin/schema.ts
+++ b/src/components/admin/schema.ts
@@ -79,7 +79,7 @@ export const collections: Collection[] = [
         folder: 'src/content/services',
         canCreate: true,
         depth: 1,
-        layoutPath: '../../layouts/page.astro',
+        layoutPath: '../../../layouts/page.astro',
         description: 'Bioinformatics services offered by ELIXIR Norway, shown at elixir.no/services. Each service has a title, summary, optional logo, tags for categorization, and an external website URL shown as a "Visit service" button.',
         fields: [
             { name: 'title', label: 'Title', type: 'string', required: true },
@@ -96,7 +96,7 @@ export const collections: Collection[] = [
         folder: 'src/content/funding-and-projects',
         canCreate: true,
         depth: 1,
-        layoutPath: '../../layouts/page.astro',
+        layoutPath: '../../../layouts/page.astro',
         description: 'Research grants and EU projects at elixir.no/funding-and-projects. Includes metadata like status (ongoing/completed), category (european/norwegian/elixir), funder info, period, external links, and keywords for filtering.',
         fields: [
             { name: 'title', label: 'Title', type: 'string', required: true },


### PR DESCRIPTION
## Summary

- The CMS schema for the \`services\` and \`funding-and-projects\` collections wrote \`layout: \"../../layouts/page.astro\"\` into the frontmatter of every newly-created page. That path resolves to \`src/content/layouts/page.astro\`, which doesn't exist, so every CMS-generated funding or service page failed to render.
- Both collections live one level deep under \`src/content/{collection}/{slug}/index.mdx\`, so the import needs three \`..\` segments (\`src/content/{collection}/{slug}/\` → \`src/layouts/\`). News and events sit one level deeper (\`.../{year}/{slug}/\`) and already use the correct four-segment path.

## Why

Reported by @korbinib in #289 for funding pages. The same bug exists in the services collection — fixing both in one commit.

## Test plan

- [x] \`pnpm build\` exits clean
- [x] Diff matches every existing service / funding file (\`grep -rn '^layout:' src/content/services src/content/funding-and-projects\` shows them all using \`../../../layouts/page.astro\`)
- [ ] Create a new funding page via the CMS, verify it builds and renders

Closes #289