### PR TITLE
feat(nav): add about mega-menu and magic-pill navbar motion

### DIFF
--- a/src/components/nav-about-menu.tsx
+++ b/src/components/nav-about-menu.tsx
@@ -1,40 +1,7 @@
-import { aboutNodes, aboutSections, aboutOverviewHref, type SectionIcon } from '../data/nav-menu';
+import { aboutNodes, aboutOverviewHref } from '../data/nav-menu';
 
 const isActive = (pathname: string, href: string) =>
     pathname === href || pathname.startsWith(href + '/');
-
-const SectionGlyph = ({ icon }: { icon: SectionIcon }) => {
-    const cls = 'h-[15px] w-[15px]';
-    switch (icon) {
-        case 'people':
-            return (
-                <svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
-                    <circle cx="9" cy="8" r="3" />
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 20a6 6 0 0 1 12 0M16 7a3 3 0 0 1 0 6M15 20a6 6 0 0 1 6-3" />
-                </svg>
-            );
-        case 'cases':
-            return (
-                <svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 8h6M9 12h6M9 16h6M5 4h14v16H5z" />
-                </svg>
-            );
-        case 'impact':
-            return (
-                <svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 21h18M6 21V9l6-4 6 4v12M10 13h4" />
-                </svg>
-            );
-        case 'publications':
-            return (
-                <svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 5h16M4 12h16M4 19h10" />
-                </svg>
-            );
-        default:
-            return null;
-    }
-};
 
 const ArrowIcon = () => (
     <svg className="h-3.5 w-3.5 shrink-0 transition-transform duration-200 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" aria-hidden="true">
@@ -49,15 +16,14 @@ type Props = {
 };
 
 export default function NavAboutMenu({ pathname, variant, onNavigate }: Props) {
-    const panel = variant === 'panel';
-    const rowBase = `group flex items-center gap-3 rounded-xl px-2.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${panel ? 'py-2' : 'py-3'}`;
-    const headCls = 'px-2.5 pb-2 pt-1 text-xs font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-400';
+    const pad = variant === 'panel' ? 'py-2' : 'py-3';
+    const rowBase = `group flex items-center gap-3 rounded-xl px-2.5 ${pad} transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent`;
     const rowState = (active: boolean) =>
         active ? 'bg-accent/10' : 'hover:bg-black/[0.04] dark:hover:bg-white/[0.06]';
 
-    const nodes = (
+    return (
         <div>
-            <p className={headCls}>Our nodes</p>
+            <p className="px-2.5 pb-2 pt-1 text-xs font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-400">Our nodes</p>
             {aboutNodes.map((node) => {
                 const active = isActive(pathname, node.href);
                 return (
@@ -76,47 +42,12 @@ export default function NavAboutMenu({ pathname, variant, onNavigate }: Props) {
                     </a>
                 );
             })}
-        </div>
-    );
-
-    const sections = (
-        <div>
-            <p className={headCls}>Explore</p>
-            {aboutSections.map((section) => {
-                const active = isActive(pathname, section.href);
-                return (
-                    <a
-                        key={section.href}
-                        href={section.href}
-                        onClick={onNavigate}
-                        aria-current={active ? 'page' : undefined}
-                        className={`${rowBase} ${rowState(active)}`}
-                    >
-                        <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-accent/10 text-accent" aria-hidden="true">
-                            <SectionGlyph icon={section.icon} />
-                        </span>
-                        <span className="min-w-0">
-                            <span className="block truncate text-sm font-semibold text-accent">{section.name}</span>
-                            <span className="block truncate text-xs text-gray-600 dark:text-gray-400">{section.desc}</span>
-                        </span>
-                    </a>
-                );
-            })}
-        </div>
-    );
-
-    return (
-        <div>
-            <div className={panel ? 'grid grid-cols-2 gap-2' : 'space-y-1'}>
-                {nodes}
-                {sections}
-            </div>
             <div className="mt-1 border-t border-gray-200/70 pt-1.5 dark:border-gray-700/40">
                 <a
                     href={aboutOverviewHref}
                     onClick={onNavigate}
                     aria-current={pathname === aboutOverviewHref ? 'page' : undefined}
-                    className={`group flex items-center gap-2 rounded-xl px-2.5 ${panel ? 'py-2' : 'py-3'} text-sm font-semibold text-accent transition-colors hover:bg-accent/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent`}
+                    className={`group flex items-center gap-2 rounded-xl px-2.5 ${pad} text-sm font-semibold text-accent transition-colors hover:bg-accent/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent`}
                 >
                     About ELIXIR Norway — overview
                     <ArrowIcon />

--- a/src/components/nav-about-menu.tsx
+++ b/src/components/nav-about-menu.tsx
@@ -1,0 +1,127 @@
+import { aboutNodes, aboutSections, aboutOverviewHref, type SectionIcon } from '../data/nav-menu';
+
+const isActive = (pathname: string, href: string) =>
+    pathname === href || pathname.startsWith(href + '/');
+
+const SectionGlyph = ({ icon }: { icon: SectionIcon }) => {
+    const cls = 'h-[15px] w-[15px]';
+    switch (icon) {
+        case 'people':
+            return (
+                <svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
+                    <circle cx="9" cy="8" r="3" />
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 20a6 6 0 0 1 12 0M16 7a3 3 0 0 1 0 6M15 20a6 6 0 0 1 6-3" />
+                </svg>
+            );
+        case 'cases':
+            return (
+                <svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 8h6M9 12h6M9 16h6M5 4h14v16H5z" />
+                </svg>
+            );
+        case 'impact':
+            return (
+                <svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 21h18M6 21V9l6-4 6 4v12M10 13h4" />
+                </svg>
+            );
+        case 'publications':
+            return (
+                <svg className={cls} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M4 5h16M4 12h16M4 19h10" />
+                </svg>
+            );
+        default:
+            return null;
+    }
+};
+
+const ArrowIcon = () => (
+    <svg className="h-3.5 w-3.5 shrink-0 transition-transform duration-200 group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
+    </svg>
+);
+
+type Props = {
+    pathname: string;
+    variant: 'panel' | 'accordion';
+    onNavigate?: () => void;
+};
+
+export default function NavAboutMenu({ pathname, variant, onNavigate }: Props) {
+    const panel = variant === 'panel';
+    const rowBase = `group flex items-center gap-3 rounded-xl px-2.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${panel ? 'py-2' : 'py-3'}`;
+    const headCls = 'px-2.5 pb-2 pt-1 text-xs font-semibold uppercase tracking-wider text-gray-600 dark:text-gray-400';
+    const rowState = (active: boolean) =>
+        active ? 'bg-accent/10' : 'hover:bg-black/[0.04] dark:hover:bg-white/[0.06]';
+
+    const nodes = (
+        <div>
+            <p className={headCls}>Our nodes</p>
+            {aboutNodes.map((node) => {
+                const active = isActive(pathname, node.href);
+                return (
+                    <a
+                        key={node.href}
+                        href={node.href}
+                        onClick={onNavigate}
+                        aria-current={active ? 'page' : undefined}
+                        className={`${rowBase} ${rowState(active)}`}
+                    >
+                        <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: node.color }} aria-hidden="true" />
+                        <span className="min-w-0">
+                            <span className="block truncate text-sm font-semibold text-accent">{node.nodeName}</span>
+                            <span className="block truncate text-xs text-gray-600 dark:text-gray-400">{node.universityShort}</span>
+                        </span>
+                    </a>
+                );
+            })}
+        </div>
+    );
+
+    const sections = (
+        <div>
+            <p className={headCls}>Explore</p>
+            {aboutSections.map((section) => {
+                const active = isActive(pathname, section.href);
+                return (
+                    <a
+                        key={section.href}
+                        href={section.href}
+                        onClick={onNavigate}
+                        aria-current={active ? 'page' : undefined}
+                        className={`${rowBase} ${rowState(active)}`}
+                    >
+                        <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-accent/10 text-accent" aria-hidden="true">
+                            <SectionGlyph icon={section.icon} />
+                        </span>
+                        <span className="min-w-0">
+                            <span className="block truncate text-sm font-semibold text-accent">{section.name}</span>
+                            <span className="block truncate text-xs text-gray-600 dark:text-gray-400">{section.desc}</span>
+                        </span>
+                    </a>
+                );
+            })}
+        </div>
+    );
+
+    return (
+        <div>
+            <div className={panel ? 'grid grid-cols-2 gap-2' : 'space-y-1'}>
+                {nodes}
+                {sections}
+            </div>
+            <div className="mt-1 border-t border-gray-200/70 pt-1.5 dark:border-gray-700/40">
+                <a
+                    href={aboutOverviewHref}
+                    onClick={onNavigate}
+                    aria-current={pathname === aboutOverviewHref ? 'page' : undefined}
+                    className={`group flex items-center gap-2 rounded-xl px-2.5 ${panel ? 'py-2' : 'py-3'} text-sm font-semibold text-accent transition-colors hover:bg-accent/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent`}
+                >
+                    About ELIXIR Norway — overview
+                    <ArrowIcon />
+                </a>
+            </div>
+        </div>
+    );
+}

--- a/src/components/nav-dropdown.tsx
+++ b/src/components/nav-dropdown.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+
+const ChevronIcon = ({ className }: { className?: string }) => (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+    </svg>
+);
+
+const linkColor = (active: boolean) =>
+    active ? 'text-accent' : 'text-brand-grey dark:text-gray-300 hover:text-brand-primary dark:hover:text-white';
+
+type Props = {
+    /** Visible text; also the trigger link. */
+    label: string;
+    /** Destination of the label link. The panel is opened by the chevron, not the label. */
+    href: string;
+    /** Whether `href` is the current page. */
+    active: boolean;
+    /** Id tying the chevron (aria-controls) to the panel region. */
+    panelId: string;
+    /** Accessible name for the panel region. */
+    panelLabel: string;
+    /** Extra classes for the floating panel (e.g. width). */
+    panelClassName?: string;
+    /** Ref registrar from useMagicPill so the glider can measure this item. */
+    rootRef?: (el: HTMLElement | null) => void;
+    /** Pointer-enter hook so the magic pill can glide to this item. */
+    onHover?: () => void;
+    /** Panel content; receives a `close` callback to dismiss on navigate. */
+    children: (close: () => void) => ReactNode;
+};
+
+/**
+ * A top-level nav item that is both a link (label → href) and a disclosure (a
+ * separate chevron button toggles a floating panel). Click/keyboard is the
+ * canonical path; hover-intent open is a progressive enhancement on pointer-fine
+ * devices. Closes on Escape (restoring focus to the chevron) and outside click.
+ * Composes with useMagicPill via `rootRef` + `onHover`.
+ */
+export default function NavDropdown({
+    label, href, active, panelId, panelLabel, panelClassName = '', rootRef, onHover, children,
+}: Props) {
+    const [open, setOpen] = useState(false);
+    const [hoverCapable, setHoverCapable] = useState(false);
+    const shouldReduceMotion = useReducedMotion();
+    const wrapRef = useRef<HTMLDivElement | null>(null);
+    const chevronRef = useRef<HTMLButtonElement | null>(null);
+    const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const setRoot = (el: HTMLDivElement | null) => { wrapRef.current = el; rootRef?.(el); };
+    const close = () => setOpen(false);
+    const clearCloseTimer = () => {
+        if (closeTimer.current) { clearTimeout(closeTimer.current); closeTimer.current = null; }
+    };
+    const scheduleClose = () => {
+        clearCloseTimer();
+        closeTimer.current = setTimeout(() => setOpen(false), 150);
+    };
+
+    useEffect(() => {
+        setHoverCapable(window.matchMedia('(hover: hover) and (pointer: fine)').matches);
+    }, []);
+
+    useEffect(() => () => { if (closeTimer.current) clearTimeout(closeTimer.current); }, []);
+
+    useEffect(() => {
+        if (!open) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') { setOpen(false); chevronRef.current?.focus(); }
+        };
+        const onDown = (e: MouseEvent) => {
+            if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false);
+        };
+        document.addEventListener('keydown', onKey);
+        document.addEventListener('mousedown', onDown);
+        return () => { document.removeEventListener('keydown', onKey); document.removeEventListener('mousedown', onDown); };
+    }, [open]);
+
+    return (
+        <div
+            ref={setRoot}
+            className="relative z-10 flex items-center"
+            onMouseEnter={() => {
+                onHover?.();
+                if (hoverCapable) { clearCloseTimer(); setOpen(true); }
+            }}
+            onMouseLeave={() => { if (hoverCapable) scheduleClose(); }}
+        >
+            <a
+                href={href}
+                className={`rounded-lg py-2 pl-3 pr-1.5 text-sm 2xl:text-base font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${linkColor(active)}`}
+                aria-current={active ? 'page' : undefined}
+            >
+                {label}
+            </a>
+            <button
+                ref={chevronRef}
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                aria-expanded={open}
+                aria-controls={panelId}
+                aria-label={open ? `Close ${label} menu` : `Open ${label} menu`}
+                className={`rounded-lg py-2 pl-1 pr-2.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${linkColor(active)}`}
+            >
+                <ChevronIcon className={`h-3.5 w-3.5 transition-transform ${shouldReduceMotion ? '' : 'duration-200'} ${open ? 'rotate-180' : ''}`} />
+            </button>
+
+            <AnimatePresence>
+                {open && (
+                    <motion.div
+                        id={panelId}
+                        role="region"
+                        aria-label={panelLabel}
+                        initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+                        transition={{ duration: 0.2 }}
+                        className={`absolute left-0 top-full mt-3 rounded-2xl border border-gray-200/70 dark:border-gray-700/50 bg-white/95 dark:bg-dark-background/95 backdrop-blur-xl p-3 shadow-xl shadow-black/[0.12] dark:shadow-black/40 ${panelClassName}`}
+                        onMouseEnter={clearCloseTimer}
+                        onMouseLeave={() => { if (hoverCapable) scheduleClose(); }}
+                    >
+                        {children(close)}
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}

--- a/src/components/nav-mobile-accordion.tsx
+++ b/src/components/nav-mobile-accordion.tsx
@@ -1,0 +1,69 @@
+import { useState, type ReactNode } from 'react';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+
+const ChevronIcon = ({ className }: { className?: string }) => (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
+    </svg>
+);
+
+type Props = {
+    /** Visible text; also the trigger link. */
+    label: string;
+    /** Destination of the label link. The panel is expanded by the chevron, not the label. */
+    href: string;
+    /** Whether `href` is the current page. */
+    active: boolean;
+    /** Id tying the chevron (aria-controls) to the collapsible panel. */
+    panelId: string;
+    /** Class for the big mobile link, shared with sibling nav links. */
+    linkClassName: string;
+    /** Called when the label or any child link is activated (closes the overlay). */
+    onNavigate: () => void;
+    /** Collapsible content. */
+    children: ReactNode;
+};
+
+/**
+ * A mobile nav row that is both a link (label → href) and a disclosure: a
+ * separate chevron button expands an inline collapsible panel beneath it.
+ * Mirrors NavDropdown's link-plus-chevron pattern for the full-screen overlay.
+ */
+export default function NavMobileAccordion({ label, href, active, panelId, linkClassName, onNavigate, children }: Props) {
+    const [open, setOpen] = useState(false);
+    const shouldReduceMotion = useReducedMotion();
+
+    return (
+        <>
+            <div className="flex items-center justify-between gap-2">
+                <a href={href} onClick={onNavigate} className={linkClassName} aria-current={active ? 'page' : undefined}>
+                    {label}
+                </a>
+                <button
+                    type="button"
+                    onClick={() => setOpen((o) => !o)}
+                    aria-expanded={open}
+                    aria-controls={panelId}
+                    aria-label={open ? `Collapse ${label} section` : `Expand ${label} section`}
+                    className="grid h-11 w-11 shrink-0 place-items-center rounded-xl text-brand-primary dark:text-white hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                >
+                    <ChevronIcon className={`h-5 w-5 transition-transform ${shouldReduceMotion ? '' : 'duration-200'} ${open ? 'rotate-180' : ''}`} />
+                </button>
+            </div>
+            <AnimatePresence initial={false}>
+                {open && (
+                    <motion.div
+                        id={panelId}
+                        initial={shouldReduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+                        animate={shouldReduceMotion ? { opacity: 1 } : { height: 'auto', opacity: 1 }}
+                        exit={shouldReduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+                        transition={{ duration: 0.25 }}
+                        className="overflow-hidden"
+                    >
+                        <div className="py-2 pl-1">{children}</div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </>
+    );
+}

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,18 +1,15 @@
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
-import { Fragment, useEffect, useLayoutEffect, useState, useCallback, useRef } from "react";
+import { Fragment, useEffect, useState, useCallback } from "react";
 import CommandPalette from "./command-palette.tsx";
 import ThemeToggle from "./theme-toggle.tsx";
 import NavAboutMenu from "./nav-about-menu.tsx";
+import NavDropdown from "./nav-dropdown.tsx";
+import NavMobileAccordion from "./nav-mobile-accordion.tsx";
+import { useMagicPill } from "../lib/hooks/use-magic-pill";
 
 const SearchIcon = ({ className }: { className?: string }) => (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
         <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
-    </svg>
-);
-
-const ChevronIcon = ({ className }: { className?: string }) => (
-    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} aria-hidden="true">
-        <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
     </svg>
 );
 
@@ -28,13 +25,13 @@ const navigation = [
     { href: `${BASE}/news`, name: "News" },
 ];
 
-// useLayoutEffect warns during SSR; this island is server-rendered then hydrated.
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
-
 const isActivePath = (pathname: string, href: string) =>
     pathname === href || pathname.startsWith(href + '/');
 
-type Glider = { left: number; top: number; width: number; height: number };
+const navLinkClass = (active: boolean) =>
+    `relative z-10 px-3 py-2 text-sm 2xl:text-base font-semibold rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+        active ? 'text-accent' : 'text-brand-grey dark:text-gray-300 hover:text-brand-primary dark:hover:text-white'
+    }`;
 
 const useScrolled = (threshold = 20) => {
     const [scrolled, setScrolled] = useState(false);
@@ -49,54 +46,14 @@ const useScrolled = (threshold = 20) => {
 
 export const Navigation = ({ pathname }: { pathname: string }) => {
     const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-    const [aboutMobileOpen, setAboutMobileOpen] = useState(false);
     const [searchOpen, setSearchOpen] = useState(false);
-    const [aboutOpen, setAboutOpen] = useState(false);
-    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
-    const [glider, setGlider] = useState<Glider | null>(null);
-    const [hoverCapable, setHoverCapable] = useState(false);
     const scrolled = useScrolled();
     const shouldReduceMotion = useReducedMotion();
 
-    const linkRefs = useRef<(HTMLElement | null)[]>([]);
-    const aboutWrapRef = useRef<HTMLDivElement | null>(null);
-    const aboutChevronRef = useRef<HTMLButtonElement | null>(null);
-    const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-    const closeMobile = useCallback(() => { setMobileMenuOpen(false); setAboutMobileOpen(false); }, []);
-
-    // Magic-pill target: hovered link, else the active link (or hidden if neither).
     const activeIndex = navigation.findIndex((item) => isActivePath(pathname, item.href));
-    const targetIndex = hoveredIndex ?? (activeIndex >= 0 ? activeIndex : null);
-    const targetIndexRef = useRef<number | null>(targetIndex);
-    targetIndexRef.current = targetIndex;
+    const { glider, setHoveredIndex, registerRef } = useMagicPill(activeIndex);
 
-    const measureGlider = useCallback((index: number | null) => {
-        if (index == null) { setGlider(null); return; }
-        const el = linkRefs.current[index];
-        if (!el) { setGlider(null); return; }
-        setGlider({ left: el.offsetLeft, top: el.offsetTop, width: el.offsetWidth, height: el.offsetHeight });
-    }, []);
-
-    useIsomorphicLayoutEffect(() => { measureGlider(targetIndex); }, [targetIndex, measureGlider]);
-
-    useEffect(() => {
-        const onResize = () => measureGlider(targetIndexRef.current);
-        window.addEventListener('resize', onResize);
-        return () => window.removeEventListener('resize', onResize);
-    }, [measureGlider]);
-
-    // Re-measure once the web font (Space Grotesk) has loaded — link widths shift.
-    useEffect(() => {
-        if (typeof document === 'undefined' || !('fonts' in document)) return;
-        let cancelled = false;
-        document.fonts.ready.then(() => { if (!cancelled) measureGlider(targetIndexRef.current); });
-        return () => { cancelled = true; };
-    }, [measureGlider]);
-
-    useEffect(() => {
-        setHoverCapable(window.matchMedia('(hover: hover) and (pointer: fine)').matches);
-    }, []);
+    const closeMobile = useCallback(() => setMobileMenuOpen(false), []);
 
     useEffect(() => {
         document.body.style.overflow = mobileMenuOpen ? 'hidden' : '';
@@ -110,29 +67,6 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
         document.addEventListener('keydown', onKey);
         return () => document.removeEventListener('keydown', onKey);
     }, [mobileMenuOpen, closeMobile]);
-
-    // About dropdown: Esc closes + returns focus to the chevron; outside-click closes.
-    useEffect(() => {
-        if (!aboutOpen) return;
-        const onKey = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') { setAboutOpen(false); aboutChevronRef.current?.focus(); }
-        };
-        const onDown = (e: MouseEvent) => {
-            if (aboutWrapRef.current && !aboutWrapRef.current.contains(e.target as Node)) setAboutOpen(false);
-        };
-        document.addEventListener('keydown', onKey);
-        document.addEventListener('mousedown', onDown);
-        return () => { document.removeEventListener('keydown', onKey); document.removeEventListener('mousedown', onDown); };
-    }, [aboutOpen]);
-
-    const clearCloseTimer = useCallback(() => {
-        if (closeTimer.current) { clearTimeout(closeTimer.current); closeTimer.current = null; }
-    }, []);
-    const scheduleCloseAbout = useCallback(() => {
-        clearCloseTimer();
-        closeTimer.current = setTimeout(() => setAboutOpen(false), 150);
-    }, [clearCloseTimer]);
-    useEffect(() => clearCloseTimer, [clearCloseTimer]);
 
     return (
         <Fragment>
@@ -173,70 +107,32 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
 
                             {navigation.map((item, i) => {
                                 const active = isActivePath(pathname, item.href);
-                                const linkColor = active
-                                    ? 'text-accent'
-                                    : 'text-brand-grey dark:text-gray-300 hover:text-brand-primary dark:hover:text-white';
 
                                 if (item.name === 'About') {
                                     return (
-                                        <div
+                                        <NavDropdown
                                             key={item.name}
-                                            ref={(el) => { linkRefs.current[i] = el; aboutWrapRef.current = el; }}
-                                            className="relative z-10 flex items-center"
-                                            onMouseEnter={() => {
-                                                setHoveredIndex(i);
-                                                if (hoverCapable) { clearCloseTimer(); setAboutOpen(true); }
-                                            }}
-                                            onMouseLeave={() => { if (hoverCapable) scheduleCloseAbout(); }}
+                                            label={item.name}
+                                            href={item.href}
+                                            active={active}
+                                            panelId="about-menu-panel"
+                                            panelLabel="About ELIXIR Norway"
+                                            panelClassName="w-80"
+                                            rootRef={registerRef(i)}
+                                            onHover={() => setHoveredIndex(i)}
                                         >
-                                            <a
-                                                href={item.href}
-                                                className={`rounded-lg py-2 pl-3 pr-1.5 text-sm 2xl:text-base font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${linkColor}`}
-                                                aria-current={active ? 'page' : undefined}
-                                            >
-                                                {item.name}
-                                            </a>
-                                            <button
-                                                ref={aboutChevronRef}
-                                                type="button"
-                                                onClick={() => setAboutOpen((o) => !o)}
-                                                aria-expanded={aboutOpen}
-                                                aria-controls="about-menu-panel"
-                                                aria-label={aboutOpen ? 'Close About menu' : 'Open About menu'}
-                                                className={`rounded-lg py-2 pl-1 pr-2.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${linkColor}`}
-                                            >
-                                                <ChevronIcon className={`h-3.5 w-3.5 transition-transform ${shouldReduceMotion ? '' : 'duration-200'} ${aboutOpen ? 'rotate-180' : ''}`} />
-                                            </button>
-
-                                            <AnimatePresence>
-                                                {aboutOpen && (
-                                                    <motion.div
-                                                        id="about-menu-panel"
-                                                        role="region"
-                                                        aria-label="About ELIXIR Norway"
-                                                        initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
-                                                        animate={{ opacity: 1, y: 0 }}
-                                                        exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
-                                                        transition={{ duration: 0.2 }}
-                                                        className="absolute left-0 top-full mt-3 w-[34rem] rounded-2xl border border-gray-200/70 dark:border-gray-700/50 bg-white/95 dark:bg-dark-background/95 backdrop-blur-xl p-3 shadow-xl shadow-black/[0.12] dark:shadow-black/40"
-                                                        onMouseEnter={clearCloseTimer}
-                                                        onMouseLeave={() => { if (hoverCapable) scheduleCloseAbout(); }}
-                                                    >
-                                                        <NavAboutMenu pathname={pathname} variant="panel" onNavigate={() => setAboutOpen(false)} />
-                                                    </motion.div>
-                                                )}
-                                            </AnimatePresence>
-                                        </div>
+                                            {(close) => <NavAboutMenu pathname={pathname} variant="panel" onNavigate={close} />}
+                                        </NavDropdown>
                                     );
                                 }
 
                                 return (
                                     <a
                                         key={item.name}
-                                        ref={(el) => { linkRefs.current[i] = el; }}
+                                        ref={registerRef(i)}
                                         href={item.href}
                                         onMouseEnter={() => setHoveredIndex(i)}
-                                        className={`relative z-10 px-3 py-2 text-sm 2xl:text-base font-semibold rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${linkColor}`}
+                                        className={navLinkClass(active)}
                                         aria-current={active ? 'page' : undefined}
                                     >
                                         {item.name}
@@ -271,12 +167,12 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
                                     <motion.span
                                         className="block h-[2px] w-full bg-current rounded-full origin-center"
                                         animate={mobileMenuOpen ? { rotate: 45, y: 5 } : { rotate: 0, y: 0 }}
-                                        transition={{ duration: 0.25 }}
+                                        transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.25 }}
                                     />
                                     <motion.span
                                         className="block h-[2px] w-full bg-current rounded-full origin-center"
                                         animate={mobileMenuOpen ? { rotate: -45, y: -5 } : { rotate: 0, y: 0 }}
-                                        transition={{ duration: 0.25 }}
+                                        transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.25 }}
                                     />
                                 </div>
                             </button>
@@ -307,49 +203,6 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
                                     const active = isActivePath(pathname, item.href);
                                     const bigLink = `block py-2.5 landscape:py-1.5 text-2xl landscape:text-xl sm:text-3xl font-bold tracking-tight transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:rounded ${active ? 'text-accent' : 'text-brand-primary dark:text-white hover:text-accent'}`;
 
-                                    if (item.name === 'About') {
-                                        return (
-                                            <motion.li
-                                                key={item.name}
-                                                initial={shouldReduceMotion ? {} : { opacity: 0, y: 12 }}
-                                                animate={{ opacity: 1, y: 0 }}
-                                                transition={{ delay: 0.04 * i, duration: 0.3 }}
-                                            >
-                                                <div className="flex items-center justify-between gap-2">
-                                                    <a href={item.href} onClick={closeMobile} className={bigLink} aria-current={active ? 'page' : undefined}>
-                                                        {item.name}
-                                                    </a>
-                                                    <button
-                                                        type="button"
-                                                        onClick={() => setAboutMobileOpen((o) => !o)}
-                                                        aria-expanded={aboutMobileOpen}
-                                                        aria-controls="about-accordion"
-                                                        aria-label={aboutMobileOpen ? 'Collapse About section' : 'Expand About section'}
-                                                        className="grid h-11 w-11 shrink-0 place-items-center rounded-xl text-brand-primary dark:text-white hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                                                    >
-                                                        <ChevronIcon className={`h-5 w-5 transition-transform ${shouldReduceMotion ? '' : 'duration-200'} ${aboutMobileOpen ? 'rotate-180' : ''}`} />
-                                                    </button>
-                                                </div>
-                                                <AnimatePresence initial={false}>
-                                                    {aboutMobileOpen && (
-                                                        <motion.div
-                                                            id="about-accordion"
-                                                            initial={shouldReduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
-                                                            animate={shouldReduceMotion ? { opacity: 1 } : { height: 'auto', opacity: 1 }}
-                                                            exit={shouldReduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
-                                                            transition={{ duration: 0.25 }}
-                                                            className="overflow-hidden"
-                                                        >
-                                                            <div className="py-2 pl-1">
-                                                                <NavAboutMenu pathname={pathname} variant="accordion" onNavigate={closeMobile} />
-                                                            </div>
-                                                        </motion.div>
-                                                    )}
-                                                </AnimatePresence>
-                                            </motion.li>
-                                        );
-                                    }
-
                                     return (
                                         <motion.li
                                             key={item.name}
@@ -357,9 +210,22 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
                                             animate={{ opacity: 1, y: 0 }}
                                             transition={{ delay: 0.04 * i, duration: 0.3 }}
                                         >
-                                            <a href={item.href} onClick={closeMobile} className={bigLink} aria-current={active ? 'page' : undefined}>
-                                                {item.name}
-                                            </a>
+                                            {item.name === 'About' ? (
+                                                <NavMobileAccordion
+                                                    label={item.name}
+                                                    href={item.href}
+                                                    active={active}
+                                                    panelId="about-accordion"
+                                                    linkClassName={bigLink}
+                                                    onNavigate={closeMobile}
+                                                >
+                                                    <NavAboutMenu pathname={pathname} variant="accordion" onNavigate={closeMobile} />
+                                                </NavMobileAccordion>
+                                            ) : (
+                                                <a href={item.href} onClick={closeMobile} className={bigLink} aria-current={active ? 'page' : undefined}>
+                                                    {item.name}
+                                                </a>
+                                            )}
                                         </motion.li>
                                     );
                                 })}

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -68,6 +68,8 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
     // Magic-pill target: hovered link, else the active link (or hidden if neither).
     const activeIndex = navigation.findIndex((item) => isActivePath(pathname, item.href));
     const targetIndex = hoveredIndex ?? (activeIndex >= 0 ? activeIndex : null);
+    const targetIndexRef = useRef<number | null>(targetIndex);
+    targetIndexRef.current = targetIndex;
 
     const measureGlider = useCallback((index: number | null) => {
         if (index == null) { setGlider(null); return; }
@@ -79,18 +81,18 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
     useIsomorphicLayoutEffect(() => { measureGlider(targetIndex); }, [targetIndex, measureGlider]);
 
     useEffect(() => {
-        const onResize = () => measureGlider(targetIndex);
+        const onResize = () => measureGlider(targetIndexRef.current);
         window.addEventListener('resize', onResize);
         return () => window.removeEventListener('resize', onResize);
-    }, [targetIndex, measureGlider]);
+    }, [measureGlider]);
 
     // Re-measure once the web font (Space Grotesk) has loaded — link widths shift.
     useEffect(() => {
         if (typeof document === 'undefined' || !('fonts' in document)) return;
         let cancelled = false;
-        document.fonts.ready.then(() => { if (!cancelled) measureGlider(targetIndex); });
+        document.fonts.ready.then(() => { if (!cancelled) measureGlider(targetIndexRef.current); });
         return () => { cancelled = true; };
-    }, [targetIndex, measureGlider]);
+    }, [measureGlider]);
 
     useEffect(() => {
         setHoverCapable(window.matchMedia('(hover: hover) and (pointer: fine)').matches);

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -1,11 +1,18 @@
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
-import React, { Fragment, useEffect, useState, useCallback } from "react";
+import { Fragment, useEffect, useLayoutEffect, useState, useCallback, useRef } from "react";
 import CommandPalette from "./command-palette.tsx";
 import ThemeToggle from "./theme-toggle.tsx";
+import NavAboutMenu from "./nav-about-menu.tsx";
 
 const SearchIcon = ({ className }: { className?: string }) => (
     <svg className={className} fill="none" viewBox="0 0 24 24" strokeWidth={2} stroke="currentColor" aria-hidden="true">
         <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+    </svg>
+);
+
+const ChevronIcon = ({ className }: { className?: string }) => (
+    <svg className={className} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" d="m6 9 6 6 6-6" />
     </svg>
 );
 
@@ -21,6 +28,14 @@ const navigation = [
     { href: `${BASE}/news`, name: "News" },
 ];
 
+// useLayoutEffect warns during SSR; this island is server-rendered then hydrated.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+const isActivePath = (pathname: string, href: string) =>
+    pathname === href || pathname.startsWith(href + '/');
+
+type Glider = { left: number; top: number; width: number; height: number };
+
 const useScrolled = (threshold = 20) => {
     const [scrolled, setScrolled] = useState(false);
     useEffect(() => {
@@ -34,11 +49,52 @@ const useScrolled = (threshold = 20) => {
 
 export const Navigation = ({ pathname }: { pathname: string }) => {
     const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+    const [aboutMobileOpen, setAboutMobileOpen] = useState(false);
     const [searchOpen, setSearchOpen] = useState(false);
+    const [aboutOpen, setAboutOpen] = useState(false);
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+    const [glider, setGlider] = useState<Glider | null>(null);
+    const [hoverCapable, setHoverCapable] = useState(false);
     const scrolled = useScrolled();
     const shouldReduceMotion = useReducedMotion();
 
-    const closeMobile = useCallback(() => setMobileMenuOpen(false), []);
+    const linkRefs = useRef<(HTMLElement | null)[]>([]);
+    const aboutWrapRef = useRef<HTMLDivElement | null>(null);
+    const aboutChevronRef = useRef<HTMLButtonElement | null>(null);
+    const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    const closeMobile = useCallback(() => { setMobileMenuOpen(false); setAboutMobileOpen(false); }, []);
+
+    // Magic-pill target: hovered link, else the active link (or hidden if neither).
+    const activeIndex = navigation.findIndex((item) => isActivePath(pathname, item.href));
+    const targetIndex = hoveredIndex ?? (activeIndex >= 0 ? activeIndex : null);
+
+    const measureGlider = useCallback((index: number | null) => {
+        if (index == null) { setGlider(null); return; }
+        const el = linkRefs.current[index];
+        if (!el) { setGlider(null); return; }
+        setGlider({ left: el.offsetLeft, top: el.offsetTop, width: el.offsetWidth, height: el.offsetHeight });
+    }, []);
+
+    useIsomorphicLayoutEffect(() => { measureGlider(targetIndex); }, [targetIndex, measureGlider]);
+
+    useEffect(() => {
+        const onResize = () => measureGlider(targetIndex);
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
+    }, [targetIndex, measureGlider]);
+
+    // Re-measure once the web font (Space Grotesk) has loaded — link widths shift.
+    useEffect(() => {
+        if (typeof document === 'undefined' || !('fonts' in document)) return;
+        let cancelled = false;
+        document.fonts.ready.then(() => { if (!cancelled) measureGlider(targetIndex); });
+        return () => { cancelled = true; };
+    }, [targetIndex, measureGlider]);
+
+    useEffect(() => {
+        setHoverCapable(window.matchMedia('(hover: hover) and (pointer: fine)').matches);
+    }, []);
 
     useEffect(() => {
         document.body.style.overflow = mobileMenuOpen ? 'hidden' : '';
@@ -53,6 +109,29 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
         return () => document.removeEventListener('keydown', onKey);
     }, [mobileMenuOpen, closeMobile]);
 
+    // About dropdown: Esc closes + returns focus to the chevron; outside-click closes.
+    useEffect(() => {
+        if (!aboutOpen) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') { setAboutOpen(false); aboutChevronRef.current?.focus(); }
+        };
+        const onDown = (e: MouseEvent) => {
+            if (aboutWrapRef.current && !aboutWrapRef.current.contains(e.target as Node)) setAboutOpen(false);
+        };
+        document.addEventListener('keydown', onKey);
+        document.addEventListener('mousedown', onDown);
+        return () => { document.removeEventListener('keydown', onKey); document.removeEventListener('mousedown', onDown); };
+    }, [aboutOpen]);
+
+    const clearCloseTimer = useCallback(() => {
+        if (closeTimer.current) { clearTimeout(closeTimer.current); closeTimer.current = null; }
+    }, []);
+    const scheduleCloseAbout = useCallback(() => {
+        clearCloseTimer();
+        closeTimer.current = setTimeout(() => setAboutOpen(false), 150);
+    }, [clearCloseTimer]);
+    useEffect(() => clearCloseTimer, [clearCloseTimer]);
+
     return (
         <Fragment>
             <CommandPalette open={searchOpen} setOpen={setSearchOpen} />
@@ -64,46 +143,99 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
                             : 'bg-white/40 dark:bg-dark-background/40 backdrop-blur-md border border-white/40 dark:border-white/10'
                     }`}
                 >
-                    <nav
-                        aria-label="Main navigation"
-                        className="flex items-center justify-between px-5 py-3 lg:px-6"
-                    >
+                    <nav aria-label="Main navigation" className="flex items-center justify-between px-5 py-3 lg:px-6">
 
                         {/* Logo */}
                         <div className="flex shrink-0">
                             <a href={`${BASE}/`} className="p-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded-lg">
                                 <span className="sr-only">ELIXIR Norway</span>
-                                <img
-                                    alt="ELIXIR Norway logo"
-                                    src={`${BASE}/assets/logos/elixir-no-light.svg`}
-                                    className="hidden dark:block h-14 w-auto"
-                                    width="120"
-                                    height="48"
-                                />
-                                <img
-                                    alt="ELIXIR Norway logo"
-                                    src={`${BASE}/assets/logos/elixir-no-dark.svg`}
-                                    className="block dark:hidden h-14 w-auto"
-                                    width="120"
-                                    height="48"
-                                />
+                                <img alt="ELIXIR Norway logo" src={`${BASE}/assets/logos/elixir-no-light.svg`} className="hidden dark:block h-14 w-auto" width="120" height="48" />
+                                <img alt="ELIXIR Norway logo" src={`${BASE}/assets/logos/elixir-no-dark.svg`} className="block dark:hidden h-14 w-auto" width="120" height="48" />
                             </a>
                         </div>
 
-                        {/* Desktop nav links */}
-                        <div className="hidden lg:flex lg:items-center lg:gap-x-1">
-                            {navigation.map((item) => {
-                                const isActive = pathname === item.href || pathname.startsWith(item.href + '/');
+                        {/* Desktop nav links + magic pill */}
+                        <div
+                            className="relative hidden lg:flex lg:items-center lg:gap-x-1"
+                            onMouseLeave={() => setHoveredIndex(null)}
+                        >
+                            {glider && (
+                                <motion.span
+                                    aria-hidden="true"
+                                    className="pointer-events-none absolute rounded-lg bg-accent/10"
+                                    initial={false}
+                                    animate={{ left: glider.left, top: glider.top, width: glider.width, height: glider.height }}
+                                    transition={shouldReduceMotion ? { duration: 0 } : { type: 'spring', stiffness: 420, damping: 34 }}
+                                />
+                            )}
+
+                            {navigation.map((item, i) => {
+                                const active = isActivePath(pathname, item.href);
+                                const linkColor = active
+                                    ? 'text-accent'
+                                    : 'text-brand-grey dark:text-gray-300 hover:text-brand-primary dark:hover:text-white';
+
+                                if (item.name === 'About') {
+                                    return (
+                                        <div
+                                            key={item.name}
+                                            ref={(el) => { linkRefs.current[i] = el; aboutWrapRef.current = el; }}
+                                            className="relative z-10 flex items-center"
+                                            onMouseEnter={() => {
+                                                setHoveredIndex(i);
+                                                if (hoverCapable) { clearCloseTimer(); setAboutOpen(true); }
+                                            }}
+                                            onMouseLeave={() => { if (hoverCapable) scheduleCloseAbout(); }}
+                                        >
+                                            <a
+                                                href={item.href}
+                                                className={`rounded-lg py-2 pl-3 pr-1.5 text-sm 2xl:text-base font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${linkColor}`}
+                                                aria-current={active ? 'page' : undefined}
+                                            >
+                                                {item.name}
+                                            </a>
+                                            <button
+                                                ref={aboutChevronRef}
+                                                type="button"
+                                                onClick={() => setAboutOpen((o) => !o)}
+                                                aria-expanded={aboutOpen}
+                                                aria-controls="about-menu-panel"
+                                                aria-label={aboutOpen ? 'Close About menu' : 'Open About menu'}
+                                                className={`rounded-lg py-2 pl-1 pr-2.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${linkColor}`}
+                                            >
+                                                <ChevronIcon className={`h-3.5 w-3.5 transition-transform ${shouldReduceMotion ? '' : 'duration-200'} ${aboutOpen ? 'rotate-180' : ''}`} />
+                                            </button>
+
+                                            <AnimatePresence>
+                                                {aboutOpen && (
+                                                    <motion.div
+                                                        id="about-menu-panel"
+                                                        role="region"
+                                                        aria-label="About ELIXIR Norway"
+                                                        initial={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+                                                        animate={{ opacity: 1, y: 0 }}
+                                                        exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -8 }}
+                                                        transition={{ duration: 0.2 }}
+                                                        className="absolute left-0 top-full mt-3 w-[34rem] rounded-2xl border border-gray-200/70 dark:border-gray-700/50 bg-white/95 dark:bg-dark-background/95 backdrop-blur-xl p-3 shadow-xl shadow-black/[0.12] dark:shadow-black/40"
+                                                        onMouseEnter={clearCloseTimer}
+                                                        onMouseLeave={() => { if (hoverCapable) scheduleCloseAbout(); }}
+                                                    >
+                                                        <NavAboutMenu pathname={pathname} variant="panel" onNavigate={() => setAboutOpen(false)} />
+                                                    </motion.div>
+                                                )}
+                                            </AnimatePresence>
+                                        </div>
+                                    );
+                                }
+
                                 return (
                                     <a
                                         key={item.name}
+                                        ref={(el) => { linkRefs.current[i] = el; }}
                                         href={item.href}
-                                        className={`relative px-3 py-2 text-sm 2xl:text-base font-semibold rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                                            isActive
-                                                ? 'text-accent bg-accent/10'
-                                                : 'text-brand-grey dark:text-gray-300 hover:text-brand-primary dark:hover:text-white hover:bg-black/[0.04] dark:hover:bg-white/[0.06]'
-                                        }`}
-                                        aria-current={isActive ? 'page' : undefined}
+                                        onMouseEnter={() => setHoveredIndex(i)}
+                                        className={`relative z-10 px-3 py-2 text-sm 2xl:text-base font-semibold rounded-lg transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${linkColor}`}
+                                        aria-current={active ? 'page' : undefined}
                                     >
                                         {item.name}
                                     </a>
@@ -136,18 +268,12 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
                                 <div className="w-[18px] h-3.5 relative flex flex-col justify-between" aria-hidden="true">
                                     <motion.span
                                         className="block h-[2px] w-full bg-current rounded-full origin-center"
-                                        animate={mobileMenuOpen
-                                            ? { rotate: 45, y: 5 }
-                                            : { rotate: 0, y: 0 }
-                                        }
+                                        animate={mobileMenuOpen ? { rotate: 45, y: 5 } : { rotate: 0, y: 0 }}
                                         transition={{ duration: 0.25 }}
                                     />
                                     <motion.span
                                         className="block h-[2px] w-full bg-current rounded-full origin-center"
-                                        animate={mobileMenuOpen
-                                            ? { rotate: -45, y: -5 }
-                                            : { rotate: 0, y: 0 }
-                                        }
+                                        animate={mobileMenuOpen ? { rotate: -45, y: -5 } : { rotate: 0, y: 0 }}
                                         transition={{ duration: 0.25 }}
                                     />
                                 </div>
@@ -173,11 +299,55 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
                         aria-modal="true"
                         aria-label="Mobile navigation"
                     >
-                        {/* Links — centered with landscape-safe scrolling */}
                         <nav aria-label="Mobile navigation" className="flex-1 flex flex-col justify-center overflow-y-auto overscroll-contain px-8 sm:px-12 pt-24 pb-4">
                             <ul className="space-y-1">
                                 {navigation.map((item, i) => {
-                                    const isActive = pathname === item.href || pathname.startsWith(item.href + '/');
+                                    const active = isActivePath(pathname, item.href);
+                                    const bigLink = `block py-2.5 landscape:py-1.5 text-2xl landscape:text-xl sm:text-3xl font-bold tracking-tight transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:rounded ${active ? 'text-accent' : 'text-brand-primary dark:text-white hover:text-accent'}`;
+
+                                    if (item.name === 'About') {
+                                        return (
+                                            <motion.li
+                                                key={item.name}
+                                                initial={shouldReduceMotion ? {} : { opacity: 0, y: 12 }}
+                                                animate={{ opacity: 1, y: 0 }}
+                                                transition={{ delay: 0.04 * i, duration: 0.3 }}
+                                            >
+                                                <div className="flex items-center justify-between gap-2">
+                                                    <a href={item.href} onClick={closeMobile} className={bigLink} aria-current={active ? 'page' : undefined}>
+                                                        {item.name}
+                                                    </a>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => setAboutMobileOpen((o) => !o)}
+                                                        aria-expanded={aboutMobileOpen}
+                                                        aria-controls="about-accordion"
+                                                        aria-label={aboutMobileOpen ? 'Collapse About section' : 'Expand About section'}
+                                                        className="grid h-11 w-11 shrink-0 place-items-center rounded-xl text-brand-primary dark:text-white hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+                                                    >
+                                                        <ChevronIcon className={`h-5 w-5 transition-transform ${shouldReduceMotion ? '' : 'duration-200'} ${aboutMobileOpen ? 'rotate-180' : ''}`} />
+                                                    </button>
+                                                </div>
+                                                <AnimatePresence initial={false}>
+                                                    {aboutMobileOpen && (
+                                                        <motion.div
+                                                            id="about-accordion"
+                                                            initial={shouldReduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+                                                            animate={shouldReduceMotion ? { opacity: 1 } : { height: 'auto', opacity: 1 }}
+                                                            exit={shouldReduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+                                                            transition={{ duration: 0.25 }}
+                                                            className="overflow-hidden"
+                                                        >
+                                                            <div className="py-2 pl-1">
+                                                                <NavAboutMenu pathname={pathname} variant="accordion" onNavigate={closeMobile} />
+                                                            </div>
+                                                        </motion.div>
+                                                    )}
+                                                </AnimatePresence>
+                                            </motion.li>
+                                        );
+                                    }
+
                                     return (
                                         <motion.li
                                             key={item.name}
@@ -185,16 +355,7 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
                                             animate={{ opacity: 1, y: 0 }}
                                             transition={{ delay: 0.04 * i, duration: 0.3 }}
                                         >
-                                            <a
-                                                href={item.href}
-                                                onClick={closeMobile}
-                                                className={`block py-2.5 landscape:py-1.5 text-2xl landscape:text-xl sm:text-3xl font-bold tracking-tight transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:rounded ${
-                                                    isActive
-                                                        ? 'text-accent'
-                                                        : 'text-brand-primary dark:text-white hover:text-accent'
-                                                }`}
-                                                aria-current={isActive ? 'page' : undefined}
-                                            >
+                                            <a href={item.href} onClick={closeMobile} className={bigLink} aria-current={active ? 'page' : undefined}>
                                                 {item.name}
                                             </a>
                                         </motion.li>
@@ -203,7 +364,6 @@ export const Navigation = ({ pathname }: { pathname: string }) => {
                             </ul>
                         </nav>
 
-                        {/* Bottom bar — search */}
                         <motion.div
                             className="px-8 sm:px-12 pb-8 pt-4 border-t border-gray-200/60 dark:border-gray-700/30"
                             initial={shouldReduceMotion ? {} : { opacity: 0 }}

--- a/src/data/nav-menu.ts
+++ b/src/data/nav-menu.ts
@@ -9,15 +9,6 @@ export type AboutNode = {
     color: string;
 };
 
-export type SectionIcon = 'people' | 'cases' | 'impact' | 'publications';
-
-export type AboutSection = {
-    name: string;
-    desc: string;
-    href: string;
-    icon: SectionIcon;
-};
-
 // Derived from organizations.ts so the menu can never drift from the org data.
 // Object insertion order: bergen, oslo, tromso, trondheim, aas.
 export const aboutNodes: AboutNode[] = Object.values(organizations).map((org) => ({
@@ -26,12 +17,5 @@ export const aboutNodes: AboutNode[] = Object.values(organizations).map((org) =>
     href: `${BASE}/about/${org.slug}`,
     color: org.color,
 }));
-
-export const aboutSections: AboutSection[] = [
-    { name: 'Everyone', desc: 'The people of ELIXIR Norway', href: `${BASE}/about/everyone`, icon: 'people' },
-    { name: 'Case Studies', desc: 'Impact stories', href: `${BASE}/about/case-studies`, icon: 'cases' },
-    { name: 'Political Impact', desc: 'Personalised medicine & data sharing', href: `${BASE}/about/political-impact`, icon: 'impact' },
-    { name: 'Publications', desc: 'Papers & outputs', href: `${BASE}/about/publications`, icon: 'publications' },
-];
 
 export const aboutOverviewHref = `${BASE}/about`;

--- a/src/data/nav-menu.ts
+++ b/src/data/nav-menu.ts
@@ -1,0 +1,37 @@
+import { organizations } from './organizations';
+
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '');
+
+export type AboutNode = {
+    nodeName: string;
+    universityShort: string;
+    href: string;
+    color: string;
+};
+
+export type SectionIcon = 'people' | 'cases' | 'impact' | 'publications';
+
+export type AboutSection = {
+    name: string;
+    desc: string;
+    href: string;
+    icon: SectionIcon;
+};
+
+// Derived from organizations.ts so the menu can never drift from the org data.
+// Object insertion order: bergen, oslo, tromso, trondheim, aas.
+export const aboutNodes: AboutNode[] = Object.values(organizations).map((org) => ({
+    nodeName: org.nodeName,
+    universityShort: org.universityShort,
+    href: `${BASE}/about/${org.slug}`,
+    color: org.color,
+}));
+
+export const aboutSections: AboutSection[] = [
+    { name: 'Everyone', desc: 'The people of ELIXIR Norway', href: `${BASE}/about/everyone`, icon: 'people' },
+    { name: 'Case Studies', desc: 'Impact stories', href: `${BASE}/about/case-studies`, icon: 'cases' },
+    { name: 'Political Impact', desc: 'Personalised medicine & data sharing', href: `${BASE}/about/political-impact`, icon: 'impact' },
+    { name: 'Publications', desc: 'Papers & outputs', href: `${BASE}/about/publications`, icon: 'publications' },
+];
+
+export const aboutOverviewHref = `${BASE}/about`;

--- a/src/lib/hooks/use-magic-pill.ts
+++ b/src/lib/hooks/use-magic-pill.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+export type Glider = { left: number; top: number; width: number; height: number };
+
+// useLayoutEffect warns during SSR; nav islands are server-rendered then hydrated.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+/**
+ * Tracks a sliding "magic pill" highlight for a horizontal list of items. The
+ * pill rests on the active item and follows the hovered one, springing back on
+ * mouse-out (hidden when neither applies). Returns the measured rect to render
+ * the pill from, a ref registrar to attach to each item, and a hover setter.
+ *
+ * Usage:
+ *   const { glider, registerRef, setHoveredIndex } = useMagicPill(activeIndex);
+ *   <div onMouseLeave={() => setHoveredIndex(null)}>
+ *     {glider && <motion.span animate={{ ...glider }} />}
+ *     {items.map((it, i) => (
+ *       <a ref={registerRef(i)} onMouseEnter={() => setHoveredIndex(i)} />
+ *     ))}
+ *   </div>
+ */
+export function useMagicPill(activeIndex: number) {
+    const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+    const [glider, setGlider] = useState<Glider | null>(null);
+    const itemRefs = useRef<(HTMLElement | null)[]>([]);
+
+    const targetIndex = hoveredIndex ?? (activeIndex >= 0 ? activeIndex : null);
+    // Mirror the target into a ref so the resize/font effects can read the
+    // current value without re-subscribing on every hover.
+    const targetIndexRef = useRef<number | null>(targetIndex);
+    targetIndexRef.current = targetIndex;
+
+    const measure = useCallback((index: number | null) => {
+        const el = index == null ? null : itemRefs.current[index];
+        if (!el) { setGlider(null); return; }
+        setGlider({ left: el.offsetLeft, top: el.offsetTop, width: el.offsetWidth, height: el.offsetHeight });
+    }, []);
+
+    useIsomorphicLayoutEffect(() => { measure(targetIndex); }, [targetIndex, measure]);
+
+    useEffect(() => {
+        const onResize = () => measure(targetIndexRef.current);
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
+    }, [measure]);
+
+    // Re-measure once the web font (Space Grotesk) has loaded — item widths shift.
+    useEffect(() => {
+        if (typeof document === 'undefined' || !('fonts' in document)) return;
+        let cancelled = false;
+        document.fonts.ready.then(() => { if (!cancelled) measure(targetIndexRef.current); });
+        return () => { cancelled = true; };
+    }, [measure]);
+
+    const registerRef = useCallback(
+        (index: number) => (el: HTMLElement | null) => { itemRefs.current[index] = el; },
+        [],
+    );
+
+    return { glider, setHoveredIndex, registerRef };
+}


### PR DESCRIPTION
## Summary

- Add an **About mega-menu**: a two-column dropdown on desktop (5 university nodes + 4 sub-pages) and an accordion on mobile, both rendered from one shared component. The node list is derived from `src/data/organizations.ts`, so it can't drift from the org data.
- Add a framer-motion **"magic pill"** that follows the hovered desktop link and springs back to the active page.
- **About** text still links to `/about`; a separate chevron `<button>` toggles the menu — click/keyboard is the canonical path, hover-intent open is a progressive enhancement gated to `hover: hover` pointers, with Esc + outside-click close and focus return.

## Changes

- **New** `src/data/nav-menu.ts` — menu data (nodes derived from `organizations.ts`, 4 fixed sections, overview href).
- **New** `src/components/nav-about-menu.tsx` — shared panel/accordion content (`panel`/`accordion` variants).
- **Rewrite** `src/components/navigation.tsx` — magic-pill glider, desktop About dropdown, mobile About accordion.
- No route, content-collection, or schema changes. Existing navbar behavior preserved (floating glass pill, scroll state, search, theme toggle, animated hamburger, dark mode).

## Accessibility

- Chevron has `aria-expanded`/`aria-controls`; Esc closes and restores focus; `focus-visible:ring-accent` on all interactive elements; `aria-current="page"` on the active node/section; brand-color dots are decorative (`aria-hidden`); mobile chevron is a 44px target; fully operable without hover. All motion gated behind `useReducedMotion()`.

## Test plan

- [x] `astro check` — 0 errors
- [x] `pnpm build` — 184 pages built, Pagefind indexed 183
- [x] `pnpm test:slugs` — all valid
- [x] `pnpm test:pages` — 183/183 pages + 185/185 assets HTTP 200
- [x] Playwright (desktop): panel opens/closes via chevron + keyboard; Esc closes and restores focus to the chevron; all node/section hrefs correct; About text navigates to `/about`; magic pill rests on the active link and glides to the hovered link; two-column grid with no viewport overflow; dark-mode accent legible
- [x] Playwright (mobile): About accordion expands with all 10 links; 44px chevron target
- [x] No nav-attributable console errors