### PR TITLE
fix(content): correct spelling mistakes

### DIFF
--- a/src/content/events/2025/elixir-industry-engagement-day/index.mdx
+++ b/src/content/events/2025/elixir-industry-engagement-day/index.mdx
@@ -12,5 +12,5 @@ Join us for a one-day event in central Oslo connecting the aquaculture industry 
 As aquaculture scales to meet global food demands, the ability to harness genomic and functional data is becoming critical for improving sustainability, productivity, and genetic gain. Yet, much of this valuable data remains underused. This event aims to bridge that gap by showcasing how European research infrastructures are making data more accessible and actionable. 
 The program contains a mix of expert talks, interactive demonstrations, and open discussions focused on real-world applications, emerging tools, and cross-sector collaboration. Whether you are in research, breeding, or innovation strategy, this is your chance to engage with major projects shaping the future of aquaculture.
 
-This workshop is funded by ELXIR Europe and the Norwegian Research Council.
+This workshop is funded by ELIXIR Europe and the Norwegian Research Council.
 For more information, see [the EUROFAANG webpage](https://eurofaang.eu/innovating-aquaculture-with-big-data-resources/)

--- a/src/content/news/2018/first-hands-on-workshop-in-marine-metagenomics-organised-in-troms/index.mdx
+++ b/src/content/news/2018/first-hands-on-workshop-in-marine-metagenomics-organised-in-troms/index.mdx
@@ -6,10 +6,10 @@ date: "Dec 4, 2018"
 cover:
     source: ./cover.png
     caption: "Taxonomic Profile"
-summary: "The first hands-on workshop in Marine Metagenomics was organised in Tromsø, November 26-30. In the workshop, the participants were introduced to the research field of metagenomcis, with focus on samples from the marine environment."
+summary: "The first hands-on workshop in Marine Metagenomics was organised in Tromsø, November 26-30. In the workshop, the participants were introduced to the research field of metagenomics, with focus on samples from the marine environment."
 tags: [training-events, genomic-data]
 ---
 
-**The first hands-on workshop in Marine Metagenomics was organised in Tromsø, November 26-30\. In the workshop, the participants were introduced to the research field of metagenomcis, with focus on samples from the marine environment.**
+**The first hands-on workshop in Marine Metagenomics was organised in Tromsø, November 26-30\. In the workshop, the participants were introduced to the research field of metagenomics, with focus on samples from the marine environment.**
 
 ELIXIR Norway, with its subnode in Tromsø, has long-standing expertise in marine metagenomics. Sub node leader in Tromsø, **Professor Nils P. Willassen**, has co-lead a work package on this subject in the ELIXIR Excelerate H2020 project, and continues to co-lead the new ELIXIR Community for marine metagenomics in the new program for ELIXIR in 2019-23.

--- a/src/content/news/2019/elixir-norway-at-the-elixir-all-hands-meeting-in-lisbon/index.mdx
+++ b/src/content/news/2019/elixir-norway-at-the-elixir-all-hands-meeting-in-lisbon/index.mdx
@@ -18,7 +18,7 @@ project, which now has come to an end. Inge Jonassen presented the
 work done in Norway to integrate NeLS, our national e-infrastructure
 for life sciences, and FAIRDOM-SEEK.
 
-We also brougth 10 posters representing the wide spectre of our work, on the Norwegian node,
+We also brought 10 posters representing the wide spectre of our work, on the Norwegian node,
 the NeLS infrastructure, SalmoBase—the integrative genomic data
 resource for salmonids, METAkube—on running METApipe over the Kubernetes
 cluster, TrackFind—on FAIR search of genomic racks, the FAIRification

--- a/src/content/news/2019/please-help-us-improve-our-bioinformatics-services/index.mdx
+++ b/src/content/news/2019/please-help-us-improve-our-bioinformatics-services/index.mdx
@@ -3,12 +3,12 @@ layout: "../../../../layouts/page.astro"
 variant: "article"
 title: "Please help us improve our bioinformatics services!"
 date: "Oct 31, 2019"
-summary: "ELIXIR Norway is now performing auser surveyto evaluate and identify gaps in our bioinformatics services."
+summary: "ELIXIR Norway is now performing a user survey to evaluate and identify gaps in our bioinformatics services."
 tags: [services]
 ---
 
 **ELIXIR Norway is now performing a [user survey](https://bit.ly/ELIXIRsurvey) to evaluate and identify gaps in our bioinformatics services.**
 
-We are grateful if you would take the time to fill out the following survey, and earn a chance to win an online gift card of the value of 1000 NOK from [GoGift](https://www.gogift.com/nb-NO/). The survey will take less than 5 minutes to complete. At the last step you will be asked to provide your email address for a chance to earn the prize draw. You may very well fill out the survey without providing your email, but we will then be unable to incude you in the prize draw.
+We are grateful if you would take the time to fill out the following survey, and earn a chance to win an online gift card of the value of 1000 NOK from [GoGift](https://www.gogift.com/nb-NO/). The survey will take less than 5 minutes to complete. At the last step you will be asked to provide your email address for a chance to earn the prize draw. You may very well fill out the survey without providing your email, but we will then be unable to include you in the prize draw.
 
 Click [here](https://bit.ly/ELIXIRsurvey) to participate in the survey, your effort is highly appreciated.

--- a/src/content/news/2020/2nd-round-of-elixir-fairdom-staff-exchange/index.mdx
+++ b/src/content/news/2020/2nd-round-of-elixir-fairdom-staff-exchange/index.mdx
@@ -14,11 +14,11 @@ schemas and tighter integration of storage infrastructure to the data
 management software [SEEK](https://docs.seek4science.org/).
 
 SEEK is the software used below e.g. the global [FAIRDOMHub](https://fairdomhub.org/)
-and used in Norway by several projects within the [Centre for Digital Life Noway](https://www.digitallifenorway.org/) and
+and used in Norway by several projects within the [Centre for Digital Life Norway](https://www.digitallifenorway.org/) and
 others. In 2018 ELIXIR Norway and the Centre for Digital Life Norway
 have been enabling the integration of the [Norwegian e-Infrastructure for Life Sciences (NeLS) and SEEK](https://fair-dom.org/2018/06/11/making-fair-data-management-easier-for-norwegian-life-science-researchers/).
 
-The four days of this staff exchange have been used to dicussed how to
+The four days of this staff exchange have been used to discuss how to
 improve the integration of SEEK with data storing infrastructures further
 and how to embed relevant metadata standards to enable easier
 deposition of datasets.

--- a/src/content/news/2020/metapipe-is-now-operational/index.mdx
+++ b/src/content/news/2020/metapipe-is-now-operational/index.mdx
@@ -3,11 +3,11 @@ layout: "../../../../layouts/page.astro"
 variant: "article"
 title: "Metapipe is now operational"
 date: "Sep 18, 2020"
-summary: "ELIXIR Norway and the Senter for Bioinformatcis at UiT have the pleasure to inform you that, after a fairly intense period of technological update, Metapipe is now operational."
+summary: "ELIXIR Norway and the Senter for Bioinformatics at UiT have the pleasure to inform you that, after a fairly intense period of technological update, Metapipe is now operational."
 tags: [services]
 ---
 
-**ELIXIR Norway and the Senter for Bioinformatcis at UiT have the
+**ELIXIR Norway and the Senter for Bioinformatics at UiT have the
 pleasure to inform you that, after a fairly intense period of
 technological update, Metapipe is now operational.**
 

--- a/src/content/news/2021/norske-sars-cov-2-gensekvenser-na-fritt-tilgjengelig-gjennom-den-apne-genbanken-ena/index.mdx
+++ b/src/content/news/2021/norske-sars-cov-2-gensekvenser-na-fritt-tilgjengelig-gjennom-den-apne-genbanken-ena/index.mdx
@@ -20,7 +20,7 @@ Willassen og ELIXIR Norge har i samarbeid med FHI utviklet en teknisk infrastruk
 - Christine Stansberg, Seniorrådgiver, Nodekoordinator ELIXIR Norge, Christine.Stansberg@uib.no +47 402 33 184
 - Inge Jonassen, Professor, Leder ELIXIR Norge, Inge.Jonassen@uib.no +47 905 24 316
 - Nils P Willassen, Professor, Nestleder ELIXIR Norge og leder ELIXIR Tromsø, nils-peder.willassen@uit.no +47 77644651
-- Anna Karin Germundson Hauge, Avdelingsdirektør, Avdeling for sbakteriologi, FHI, Anna.Hauge@fhi.no +47 464 86 056
+- Anna Karin Germundson Hauge, Avdelingsdirektør, Avdeling for bakteriologi, FHI, Anna.Hauge@fhi.no +47 464 86 056
   
 ELIXIR Norge: https://elixir.no  
 FHI: https://www.fhi.no  

--- a/src/content/news/2024/elixir4-celebration/index.mdx
+++ b/src/content/news/2024/elixir4-celebration/index.mdx
@@ -15,6 +15,6 @@ This achievement underscores the importance of ELIXIR as an intergovernmental or
 
 Our gratitude is extended to our project partners at all five universities, as well as the Norwegian Institute of Public Health (FHI) and the Norwegian Veterinary Institute. The support across the partner institutions has been invaluable, with contributions from rectors, deans, and department heads.
 
-This has been made possible by the ELIXIR Noway sub-node leaders, coordinators and everyone in ELIXIR Norway through their dedication and collaboration. Together, we are excited to enable life sciences in Norway and beyond!
+This has been made possible by the ELIXIR Norway sub-node leaders, coordinators and everyone in ELIXIR Norway through their dedication and collaboration. Together, we are excited to enable life sciences in Norway and beyond!
 
 ![Sushma Grellscheid and Inge Jonassen celebrating ELIXIR4](./elixir4-celebration.png "Sushma Grellscheid and Inge Jonassen celebrating ELIXIR4 – Photography: Randi Eilertsen")

--- a/src/content/news/2025/charm-eu-open-science-recognition-award/index.mdx
+++ b/src/content/news/2025/charm-eu-open-science-recognition-award/index.mdx
@@ -2,7 +2,7 @@
 layout: "../../../../layouts/page.astro"
 variant: "article"
 title: "CHARM-EU Open Science Recognition Award"
-date: "Octotber 06, 2025"
+date: "October 06, 2025"
 cover:
     source: ./charm-eu-award.jpg
 summary: "Congratulations to Korbinian Bösl who has won the 2025 CHARM-EU Open Science Recognition Award"

--- a/src/content/news/2025/nels-scheduled-maintenance-november/index.mdx
+++ b/src/content/news/2025/nels-scheduled-maintenance-november/index.mdx
@@ -5,10 +5,10 @@ title: "NeLS Scheduled maintenance November 4-5 2025"
 date: "October 27, 2025"
 cover:
     source: ./cover-nels-maint.png
-summary: "The NeLS system is continously improved and we are replacing our front end servers on November 4-5"
+summary: "The NeLS system is continuously improved and we are replacing our front end servers on November 4-5"
 tags: [infrastructure]
 ---
-The Norwegian e-infrastructure for Life Science (NeLS) is ELIXIR Norway's main services for researchers to manage their life science data, and is a core system we are continuosly working to enhance and improve.
+The Norwegian e-infrastructure for Life Science (NeLS) is ELIXIR Norway's main services for researchers to manage their life science data, and is a core system we are continuously working to enhance and improve.
 
 Scheduled Maintenance Downtime : We will upgrade our front-end services in NeLS on November 4th (from 0800) and 5th (until 2000), and your friendly NeLS services will after that be available on the URL https://nels.elixir.no instead of https://nels.bioinfo.no.
 

--- a/src/content/news/2026/jaspar-cdr/index.mdx
+++ b/src/content/news/2026/jaspar-cdr/index.mdx
@@ -5,7 +5,7 @@ title: "JASPAR recognised as an ELIXIR Core Data Resource"
 date: "Jan 12, 2026"
 cover:
     source: ./jaspar-cdr.png
-summary: "JASPAR, the long-standing and widely used database for transcription factor binding profiles, is now recognised as an ELXIR Core Data Resource. The work behind this service is led by Anthony Mathelier, Associate Director and Group Leader of the Computational Biology & Gene Regulation group at the Norwegian Centre for Molecular Biosciences and Medicine (NCMBM) at the University of Oslo. ELIXIR Norway's personnel play an essential role in JASPAR's maintenance, development, and operation."
+summary: "JASPAR, the long-standing and widely used database for transcription factor binding profiles, is now recognised as an ELIXIR Core Data Resource. The work behind this service is led by Anthony Mathelier, Associate Director and Group Leader of the Computational Biology & Gene Regulation group at the Norwegian Centre for Molecular Biosciences and Medicine (NCMBM) at the University of Oslo. ELIXIR Norway's personnel play an essential role in JASPAR's maintenance, development, and operation."
 tags: [services, infrastructure, open-science]
 ---
 ELIXIR has announced the life science data resources selected in the latest round of its Core Data Resources and Deposition Databases. Among the six newly approved Core Data Resources is JASPAR, 

--- a/src/content/news/2026/nordic-ds-network-meeting/index.mdx
+++ b/src/content/news/2026/nordic-ds-network-meeting/index.mdx
@@ -6,7 +6,7 @@ date: "May 7, 2026"
 cover:
     source: ./ndsn.png
 summary: "The Nordic Data Stewardship Network had its second annual meeting in Finland. Dr Federico Bianchini (ELIXIR Norway) is part of the steering group and contributed with a presentation on the Norwegian work on Data Management Planning."
-tags: [data managment, fair data, nordics]
+tags: [data-management, fair-data, nordics]
 authors: ["federico-bianchini"]
 ---
 

--- a/src/content/news/2026/strengthening-fair-metadata-standards/index.mdx
+++ b/src/content/news/2026/strengthening-fair-metadata-standards/index.mdx
@@ -1,7 +1,7 @@
 ---
 layout: "../../../../layouts/page.astro"
 variant: "article"
-title: "Strengtening FAIR Metadata Standards for Non-Human Pathogen Data"
+title: "Strengthening FAIR Metadata Standards for Non-Human Pathogen Data"
 date: "April 20, 2026"
 cover:
     source: ./fair.png
@@ -10,4 +10,4 @@ tags: [pathogen, fair-data, open-science]
 ---
 ELIXIR Norway is contributing to improved discoverability and reuse of non-human pathogen data through the project [Building FAIR metadata standards for non-human pathogen genomic and phenotypic data](https://elixir-europe.org/how-we-work/scientific-programme/science/bfsp/fairnhp), funded by the ELIXIR Commissioned Services programme. The project addresses fragmentation in data submission and metadata practices across veterinary, plant, and environmental domains. Through structured interviews and community workshops, the initiative identifies key gaps and promotes harmonised metadata standards aligned with international frameworks. The goal is to enable earlier discovery, improved interoperability, and more effective reuse of pathogen data across sectors, supporting surveillance, research, and One Health preparedness.
 
-Grapic by: SangyaPundir [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:FAIR_data_principles.jpg) [Attribution-Share Alike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/deed.en) 
+Graphic by: SangyaPundir [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:FAIR_data_principles.jpg) [Attribution-Share Alike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/deed.en)

--- a/src/data/people.json
+++ b/src/data/people.json
@@ -275,12 +275,12 @@
           "photo": "/data/people/federico-bianchini.png",
           "profile-url": "https://www.mn.uio.no/bils/english/people/fredebi/",
           "affiliations": [],
-            "elixir-groups": [
-		{
-		    "name": "coordinators",
-		    "role": "Depuy Training Coordinator"
-		}
-	    ]
+          "elixir-groups": [
+            {
+              "name": "coordinators",
+              "role": "Deputy Training Coordinator"
+            }
+          ]
         },
         {
           "username": "victor-kalbskopf",


### PR DESCRIPTION
## Summary
- Correct visible spelling mistakes across news and event MDX content.
- Fix the deputy training coordinator role typo in people data.
- Normalize corrected data-management tags to the existing hyphenated tag format.

## Test plan
- `nvm use 24 && corepack enable && pnpm install --frozen-lockfile && pnpm build && pnpm test:pages`
