### PR TITLE
Add ELIXIR Norway events at Arendalsuka 2026

### DIFF
--- a/src/content/news/2026/Arendalsuka
+++ b/src/content/news/2026/Arendalsuka
@@ -1,0 +1,44 @@
+# ELIXIR Norway at Arendalsuka 2026: Two Panel Debates on the Future of Health Data
+
+This week, ELIXIR Norway takes part in Arendalsuka with two panel debates that both address one of the most pressing questions in research and health today: how can we share and collaborate on data in a way that is safe, responsible and sustainable — both in Norway and across Europe.
+
+## Health Data Without Borders? Europe's Next Major Infrastructure Push
+**Tuesday, 11 August, 11:00–11:45, Bølgen 3 (in collaboration with EHiN)**
+
+Europe is now investing heavily in both genomic data and broader health data sharing through initiatives such as 1+Million Genomes (1+MG) and the European Health Data Space (EHDS). The goal is better healthcare services, more personalised medicine, and stronger research and innovation through safe and responsible use of data.
+
+However, these initiatives are being developed in parallel at both European and national level, involving different actors, needs and perspectives — creating a clear need for coordination, interoperability and shared solutions across research, healthcare and national borders. From a Norwegian research perspective, this requires collaboration across health registries, biobanks, national research communities and infrastructures such as ELIXIR Norway, as well as active participation in the European initiatives.
+
+Panel participants:
+- **Sushma Grellscheid**, Head of ELIXIR Norway
+- Mariann Hornnes, Deputy Director General, Norwegian Directorate of Health
+- Eivind Hovig, Professor, Oslo University Hospital
+- Therese Haugdahl Nøst, Professor, UiT/HUNT Research Centre, NTNU
+- Even Birkeland, Senior Adviser, Norwegian Institute of Public Health
+- **Moderator:** Hans Jacob Moe, health technology adviser and consultant
+
+The session will be livestreamed via EHiN's Arendalsuka programme: https://www.youtube.com/live/Zos10rrQl5Q
+
+## Can We Share Data Without Sharing?
+**Thursday, 13 August, 10:00–10:45, the Artificial Intelligence tent, Tyholmen (organised by the University of Bergen)**
+
+Data security, sharing and storage have been high on the agenda in recent years, and the topic became even more pressing in 2025 following political attacks in the US on research and academic freedom. Within research infrastructure, this has been a particular challenge for the many research databases in biology, medicine and climate science, where previously reliable American partners now appear less predictable.
+
+The debate highlights federated database systems as a possible solution: local databases can retain their independence while still being connected to function as one. This provides greater data sovereignty, security and control, since data is stored locally rather than gathered by an external party — something that is especially important when handling highly sensitive data, such as human genetic data. Such systems can also be linked with AI and search algorithms so that results are shared, without the underlying data itself being shared.
+
+Panel participants:
+- **Sushma Nagaraja Grellscheid**, Professor, UiB/ELIXIR Norway (speaker)
+- **Korbinian Bösl**, Data Management Coordinator, UiB/ELIXIR Norway (speaker)
+- Inge Jonassen, Professor and Head of Department, UiB (speaker)
+- Gunnar Brataas, Senior Research Scientist, SINTEF Digital (speaker)
+- **Chair:** Dag Stenvoll, Coordinator, UiB AI
+
+The session will be held in English.
+
+## Why This Matters for ELIXIR Norway
+
+Both debates point to the same underlying question: how do we build a data infrastructure that improves research and healthcare without compromising on security, privacy and national control? As the Norwegian node of the pan-European research infrastructure collaboration ELIXIR, this is at the core of our work — whether it concerns coordination with European health data initiatives such as EHDS and 1+MG, or the development of robust, federated solutions for sensitive research data.
+
+We thank EHiN, the University of Bergen and Arendalsuka for the opportunity to contribute to these important conversations, and we look forward to good discussions with policymakers, authorities, researchers and industry.
+
+*Follow ELIXIR.no for updates, and watch the sessions in recording via EHiN's livestreams and the Arendalsuka programme.*


### PR DESCRIPTION
Added details about ELIXIR Norway's participation in Arendalsuka 2026, including panel debates on health data sharing and security.