### PR TITLE
feat(news): add Arendalsuka 2026 article

### DIFF
--- a/src/content/news/2026/elixir-norway-at-arendalsuka-2026/index.mdx
+++ b/src/content/news/2026/elixir-norway-at-arendalsuka-2026/index.mdx
@@ -1,0 +1,56 @@
+---
+layout: "../../../../layouts/page.astro"
+variant: "article"
+title: "ELIXIR Norway at Arendalsuka 2026"
+date: "Aug 10, 2026"
+summary: "ELIXIR Norway takes part in Arendalsuka 2026 with two panel debates on the future of health and research data infrastructure: one on Europe's coordination of genomic and health data sharing, and one on federated systems as a way to share results without sharing the underlying data."
+tags: [meetings, health-data, genomic-data, infrastructure]
+authors: ["ingeborg-winge"]
+---
+
+This week, ELIXIR Norway is taking part in [Arendalsuka](https://www.arendalsuka.no/), Norway's largest political festival, with two panel debates on the future of health and research data infrastructure.
+
+## Health Data Without Borders? Europe's Next Major Infrastructure Push
+
+**Tuesday, 11 August · 11:00-11:45 CEST · Bølgen 3, Arendal**
+Organised in collaboration with [EHiN](https://ehin.no/arendalsuka-2026/)
+
+Europe is investing heavily in genomic data and broader health data sharing through initiatives such as [1+Million Genomes (1+MG)](https://digital-strategy.ec.europa.eu/en/policies/1-million-genomes) and the [European Health Data Space (EHDS)](https://health.ec.europa.eu/ehealth-digital-health-and-care/european-health-data-space_en). These efforts aim to improve healthcare, enable more personalised medicine, and strengthen research and innovation through the safe, responsible use of data.
+
+Because these initiatives are developing in parallel at both European and national level, coordination and interoperability across research, healthcare and national borders are essential. From a Norwegian research perspective, this means closer collaboration across health registries, biobanks, national research communities, and infrastructures like ELIXIR Norway, alongside active participation in the European initiatives themselves.
+
+**Panel:**
+
+- Sushma Grellscheid, Head of ELIXIR Norway
+- Mariann Hornnes, Deputy Director General, Norwegian Directorate of Health
+- Eivind Hovig, Professor, Oslo University Hospital
+- Therese Haugdahl Nøst, Professor, UiT / HUNT Research Centre, NTNU
+- Even Birkeland, Senior Adviser, Norwegian Institute of Public Health
+- *Moderator:* Hans Jacob Moe
+
+## Can We Share Data Without Sharing?
+
+**Thursday, 13 August · 10:00-10:45 CEST · AI tent, Tyholmen, Arendal**
+Organised by the University of Bergen
+
+Data security, sharing, and storage have been high on the agenda in recent years, and the topic became even more pressing in 2025 following political attacks in the US on research and academic freedom, which have made previously reliable American research infrastructure partners appear less predictable.
+
+This session explores **federated database systems** as a possible answer: local databases retain independence while still being connected to function as a single system. This increases data sovereignty, security, and control, since data stays local rather than being centralised with an external party, which matters particularly for highly sensitive data such as human genetic data. Federated systems can also be combined with AI and search algorithms so that results are shared without sharing the underlying data itself.
+
+**Panel:**
+
+- Sushma Nagaraja Grellscheid, Professor, UiB / ELIXIR Norway
+- Korbinian Bösl, Data Management Coordinator, UiB / ELIXIR Norway
+- Inge Jonassen, Professor and Head of Department, UiB
+- Gunnar Brataas, Senior Research Scientist, SINTEF Digital
+- *Chair:* Dag Stenvoll, Coordinator, UiB AI
+
+*Session held in English.*
+
+## Why it matters
+
+Both sessions point to the same underlying question: how do we build data infrastructure that improves research and healthcare without compromising security, privacy, and national control? As Norway's node in the pan-European [ELIXIR](https://elixir-europe.org/) research infrastructure, this is central to our work, from coordinating with European health data initiatives like EHDS and 1+MG, to developing robust, federated solutions for sensitive research data.
+
+Thanks to EHiN, the University of Bergen, and Arendalsuka for the opportunity to contribute to these discussions.
+
+More info: follow the sessions via the [EHiN Arendalsuka programme](https://ehin.no/arendalsuka-2026/) and the [Arendalsuka programme](https://www.arendalsuka.no/program).


### PR DESCRIPTION
Adds the news article for Arendalsuka 2026, covering the two panel debates this week.

- **Tue 11 Aug**, Health Data Without Borders? Europe's Next Major Infrastructure Push, with EHiN
- **Thu 13 Aug**, Can We Share Data Without Sharing?, with UiB

Author is Ingeborg Winge. ELIXIR Norway is not listed in the frontmatter because `page.astro` appends it to every article automatically; adding it would print it twice.

No cover image yet, so the article has no `cover` field and will fall back to the placeholder on cards. Happy to add one later.

Published date is today, 10 August 2026, so it lands ahead of both sessions.

`pnpm build` and `pnpm test:slugs` pass.
