### PR TITLE
style(news): put the Arendalsuka session details in callouts

### DIFF
--- a/src/content/news/2026/elixir-norway-at-arendalsuka-2026/index.mdx
+++ b/src/content/news/2026/elixir-norway-at-arendalsuka-2026/index.mdx
@@ -8,12 +8,15 @@ tags: [meetings, health-data, genomic-data, infrastructure]
 authors: ["ingeborg-winge"]
 ---
 
+import Callout from "../../../../components/callout.tsx";
+
 This week, ELIXIR Norway is taking part in [Arendalsuka](https://www.arendalsuka.no/), Norway's largest political festival, with two panel debates on the future of health and research data infrastructure.
 
 ## Health Data Without Borders? Europe's Next Major Infrastructure Push
 
-**Tuesday, 11 August · 11:00-11:45 CEST · Bølgen 3, Arendal**
-Organised in collaboration with [EHiN](https://ehin.no/arendalsuka-2026/)
+<Callout variant="info" title="Tuesday 11 August · 11:00-11:45 CEST">
+    Bølgen 3, Arendal. Organised in collaboration with [EHiN](https://ehin.no/arendalsuka-2026/).
+</Callout>
 
 Europe is investing heavily in genomic data and broader health data sharing through initiatives such as [1+Million Genomes (1+MG)](https://digital-strategy.ec.europa.eu/en/policies/1-million-genomes) and the [European Health Data Space (EHDS)](https://health.ec.europa.eu/ehealth-digital-health-and-care/european-health-data-space_en). These efforts aim to improve healthcare, enable more personalised medicine, and strengthen research and innovation through the safe, responsible use of data.
 
@@ -30,8 +33,9 @@ Because these initiatives are developing in parallel at both European and nation
 
 ## Can We Share Data Without Sharing?
 
-**Thursday, 13 August · 10:00-10:45 CEST · AI tent, Tyholmen, Arendal**
-Organised by the University of Bergen
+<Callout variant="info" title="Thursday 13 August · 10:00-10:45 CEST">
+    AI tent, Tyholmen, Arendal. Organised by the University of Bergen. Session held in English.
+</Callout>
 
 Data security, sharing, and storage have been high on the agenda in recent years, and the topic became even more pressing in 2025 following political attacks in the US on research and academic freedom, which have made previously reliable American research infrastructure partners appear less predictable.
 
@@ -44,8 +48,6 @@ This session explores **federated database systems** as a possible answer: local
 - Inge Jonassen, Professor and Head of Department, UiB
 - Gunnar Brataas, Senior Research Scientist, SINTEF Digital
 - *Chair:* Dag Stenvoll, Coordinator, UiB AI
-
-*Session held in English.*
 
 ## Why it matters
 


### PR DESCRIPTION
Follow-up to #314. Moves the session logistics into `Callout` blocks so the when and where stand out from the prose.

```mdx
<Callout variant="info" title="Tuesday 11 August · 11:00-11:45 CEST">
    Bølgen 3, Arendal. Organised in collaboration with [EHiN](https://ehin.no/arendalsuka-2026/).
</Callout>
```

Applied to both sessions rather than only the first, since two identically shaped blocks styled differently would read as a mistake. "Session held in English" moves up into the second callout, where the rest of the practical detail lives, instead of trailing the panel list.

`Callout` already existed and is used this way in a 2023 article, so no component changes.

`pnpm build` and `pnpm test:slugs` pass.
