### PR TITLE
fix(typography): restore the heading hierarchy in articles

### DIFF
--- a/src/components/elements.tsx
+++ b/src/components/elements.tsx
@@ -25,28 +25,35 @@ export const LI: React.FC<React.LiHTMLAttributes<HTMLLIElement>> = (props) => (
     <li {...props} className="mb-1 pl-12 -indent-6"/>
 );
 
+// These step down with the page title in `page.astro`, which is
+// text-3xl/4xl/5xl. Each level has to be responsive for the same reason the
+// title is: fixed sizes here meant an h2 that matched the title at 640px and
+// overtook it below that, so the deeper heading looked like the page heading.
 export const H1: React.FC<React.HTMLAttributes<HTMLHeadingElement>> = ({ className, ...props }) => (
-    <h1 {...props} className={className || "text-4xl font-bold mt-8 mb-4 scroll-mt-12"}/>
+    <h1 {...props} className={className || "text-2xl sm:text-3xl md:text-4xl font-bold mt-8 mb-4 scroll-mt-12"}/>
 );
 
 export const H2: React.FC<React.HTMLAttributes<HTMLHeadingElement>> = (props) => (
-    <h2 {...props} className="text-3xl font-semibold mt-8 mb-3 scroll-mt-12"/>
+    <h2 {...props} className="text-xl sm:text-2xl md:text-3xl font-semibold mt-8 mb-3 scroll-mt-12"/>
 );
 
 export const H3: React.FC<React.HTMLAttributes<HTMLHeadingElement>> = (props) => (
-    <h3 {...props} className="text-2xl font-semibold mt-5 mb-2 scroll-mt-12"/>
+    <h3 {...props} className="text-lg sm:text-xl md:text-2xl font-semibold mt-5 mb-2 scroll-mt-12"/>
 );
 
 export const H4: React.FC<React.HTMLAttributes<HTMLHeadingElement>> = (props) => (
-    <h4 {...props} className="text-xl font-semibold mt-4 mb-2 scroll-mt-12"/>
+    <h4 {...props} className="text-lg md:text-xl font-semibold mt-4 mb-2 scroll-mt-12"/>
 );
 
+// h5 and h6 land on the body size rather than below it. A heading set smaller
+// than the text it introduces reads as a caption; weight and the display face
+// carry the distinction at this depth instead.
 export const H5: React.FC<React.HTMLAttributes<HTMLHeadingElement>> = (props) => (
-    <h5 {...props} className="text-lg font-semibold mt-3 mb-2 scroll-mt-12"/>
+    <h5 {...props} className="text-lg font-bold mt-3 mb-2 scroll-mt-12"/>
 );
 
 export const H6: React.FC<React.HTMLAttributes<HTMLHeadingElement>> = (props) => (
-    <h6 {...props} className="text-base font-semibold mt-3 mb-2 scroll-mt-12"/>
+    <h6 {...props} className="text-lg font-semibold mt-3 mb-2 scroll-mt-12"/>
 );
 
 export const P: React.FC<React.HTMLAttributes<HTMLParagraphElement>> = (props) => (

--- a/src/layouts/page.astro
+++ b/src/layouts/page.astro
@@ -278,7 +278,7 @@ const jsonLd = contentType === 'news' ? JSON.stringify({
                         )}
 
                         {finalTitle && (
-                            <h1 class="text-2xl sm:text-3xl md:text-4xl font-bold tracking-tight text-brand-primary dark:text-white text-balance leading-[1.15]">
+                            <h1 class="text-3xl sm:text-4xl md:text-5xl font-bold tracking-tight text-brand-primary dark:text-white text-balance leading-[1.15]">
                                 {finalTitle}
                             </h1>
                         )}


### PR DESCRIPTION
The article title and the headings inside the body were sized in two different places that had never been reconciled: the title in `page.astro`, the content headings in `elements.tsx`.

**Before**

| width | title | h2 | body |
|---|---|---|---|
| 375 | 24 | **30** | 18 |
| 768 | 36 | 30 | 18 |
| 1440 | 36 | 30 | 18 |

On desktop the title was only 1.2x the h2 under it. Below 640px it was worse: the h2 was *bigger* than the article title, so the section heading outranked the page heading on every phone.

**After**

| width | title | h2 | h3 | h4 | body |
|---|---|---|---|---|---|
| 375 | 30 | 20 | 18 | 18 | 18 |
| 768 | 48 | 30 | 24 | 20 | 18 |
| 1440 | 48 | 30 | 24 | 20 | 18 |

Title/h2 holds between 1.5 and 1.6 from 320px up. No horizontal overflow at any width tested (320, 375, 640, 768, 1024, 1440).

The content headings had to become responsive for this to hold; fixed sizes were the reason the scale inverted on small screens.

Also: h5 and h6 were 18px and 16px against 18px body, so a heading was the same size as or smaller than the text it introduced. Both now sit at body size and separate by weight.

Only the shared page title and the MDX heading components change, so this applies to every content page (news, events, services, funding), not just news.

`pnpm build` passes, 0 errors.
