### PR TITLE
harmonising tags/keywords

### DIFF
--- a/src/content/news/2026/gdi-node-hackathon-finland/index.mdx
+++ b/src/content/news/2026/gdi-node-hackathon-finland/index.mdx
@@ -6,7 +6,7 @@ date: "March 11, 2026"
 cover:
     source: ./cover.png
 summary: "ELIXIR Norway participated in a three-day GDI hackathon in Finnish Lapland, where 59 developers from 19 EU countries advanced the federated Genomic Data Infrastructure for secure cross-border genomic data sharing."
-tags: [genomic-data, gdi, hackathon, european-collaboration]
+tags: [genomic-data, infrastructure, hackathon, european-collaboration]
 authors: ["kjell-petersen", "yasin-miran"]
 ---
 


### PR DESCRIPTION
Removing "gdi" as a keyword, as it is used only for this news item and because we already have both "infrastructure" and "genomic-data" in use, which pretty much cover the topic. Also, the name (or acronym) of a specific project is not used in any other news item. 

Ideally, we should agree in the future on which keywords to use and enforce some control over their usage, with the final aim of preventing proliferation of new keywords.